### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,14 @@ RUN apt-get update && apt-get install -y git \
 WORKDIR /workspace
 RUN git clone --recursive https://github.com/ska-sa/katcp_devel.git
 WORKDIR /workspace/katcp_devel
+# This is hacky and won't work if the Makefile.inc file changes for some reason,
+# but it'll change the KATCP version compiled from 4.9 to 5.0:
+RUN sed -i '58s/.*/CFLAGS += -DKATCP_PROTOCOL_MAJOR_VERSION=5 -DKATCP_PROTOCOL_MINOR_VERSION=0/' Makefile.inc
 RUN make
 RUN make -C katcp install
 
 WORKDIR /workspace
+RUN true
 RUN git clone --recursive https://github.com/ska-sa/RoachAcquisitionServer.git
 WORKDIR /workspace/RoachAcquisitionServer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:9.13-slim
+
+RUN apt-get update && apt-get install -y git \
+    build-essential \
+    cmake \
+    libboost-system1.62-dev \
+    libboost-thread1.62-dev \
+    libboost-program-options1.62-dev \
+    libboost-filesystem1.62-dev \
+    libhdf5-dev
+
+WORKDIR /workspace
+RUN git clone --recursive https://github.com/ska-sa/katcp_devel.git
+WORKDIR /workspace/katcp_devel
+RUN make
+RUN make -C katcp install
+
+WORKDIR /workspace
+RUN git clone --recursive https://github.com/ska-sa/RoachAcquisitionServer.git
+WORKDIR /workspace/RoachAcquisitionServer
+
+RUN cmake .
+RUN make

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN make
 RUN make -C katcp install
 
 WORKDIR /workspace
-RUN true
 RUN git clone --recursive https://github.com/ska-sa/RoachAcquisitionServer.git
 WORKDIR /workspace/RoachAcquisitionServer
 


### PR DESCRIPTION
I add this Dockerfile which will build the RoachAcquisitionServer with whatever version of katcp is in `katcp_devel`. I'm not sure if one needs to give it any specific flags or if it defaults to V5.

I haven't tested it on my laptop, but it should in principle be possible to use Docker to have both old and new veresions side-by-side, and then the beauty of it is that they don't interfere with each other.

I can probably test it a bit more thoroughly. Will try to fire up the ROACH2 again when I'm in the office. One would need to craft the `docker run` command fairly carefully to make sure that the program has access to all the configuration and stuff, and the Roach Launcher scripts would still need to be added to this.

But in principle it should work just with this fairly easy-to-use example.

I build it with `docker build -t roach:1 .` just for lack of a better tag.