### PR TITLE
Dockerfile katcp v5 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get update && apt-get install -y git \
 
 WORKDIR /workspace
 RUN git clone --recursive https://github.com/ska-sa/katcp_devel.git
+WORKDIR /workspace/katcp_devel
 # Change to KATCP v5.0
 RUN git checkout version-5.0
-WORKDIR /workspace/katcp_devel
 RUN make
 RUN make -C katcp install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,9 @@ RUN apt-get update && apt-get install -y git \
 
 WORKDIR /workspace
 RUN git clone --recursive https://github.com/ska-sa/katcp_devel.git
+# Change to KATCP v5.0
+RUN git checkout version-5.0
 WORKDIR /workspace/katcp_devel
-# This is hacky and won't work if the Makefile.inc file changes for some reason,
-# but it'll change the KATCP version compiled from 4.9 to 5.0:
-RUN sed -i '58s/.*/CFLAGS += -DKATCP_PROTOCOL_MAJOR_VERSION=5 -DKATCP_PROTOCOL_MINOR_VERSION=0/' Makefile.inc
 RUN make
 RUN make -C katcp install
 


### PR DESCRIPTION
Updated the Makefile to change the version from KATCP V4 to V5 caused the protocol version in the KATCP server startup messages to report 'dirty' (since the repo was modified). I created a new branch on katcp_devel (version-5.0) and modified the Makefile. This now references this new branch. I have tested on a Debian Jessie VM.

AT-952