### PR TITLE
Dockerfile update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM debian:9.13-slim
+FROM debian:10.13-slim
 
 RUN apt-get update && apt-get install -y git \
     build-essential \
     cmake \
-    libboost-system1.62-dev \
-    libboost-thread1.62-dev \
-    libboost-program-options1.62-dev \
-    libboost-filesystem1.62-dev \
+    libboost-system-dev \
+    libboost-thread-dev \
+    libboost-program-options-dev \
+    libboost-filesystem-dev \
     libhdf5-dev \
     python2.7 \
     python-pip \


### PR DESCRIPTION
In late April 2023, the Stretch repositories were removed from the main mirrors. The docker images uses debian-9.13 as the base, which now fails. Updated dockerfile to use debian 10.13.

I did build this on the SDB server in Ghana sucessfully.

[AT-1126](https://skaafrica.atlassian.net/browse/AT-1126)

[AT-1126]: https://skaafrica.atlassian.net/browse/AT-1126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ