### PR TITLE
Add observed maser vlsr and radec/azel offsets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,27 @@
 [submodule "AVNUtilLibs/Sockets"]
 	path = AVNUtilLibs/Sockets
-	url = https://github.com/ska-sa/AVNSockets.git
+	url = git@github.com/ska-sa/AVNSockets.git
 [submodule "AVNUtilLibs/DataStructures"]
 	path = AVNUtilLibs/DataStructures
-	url = https://github.com/ska-sa/AVNDataStructures.git
+	url = git@github.com/ska-sa/AVNDataStructures.git
 [submodule "AVNAppLibs/SocketStreamers"]
 	path = AVNAppLibs/SocketStreamers
-	url = https://github.com/ska-sa/AVNSocketStreamers.git
+	url = git@github.com/ska-sa/AVNSocketStreamers.git
 [submodule "AVNDataTypes/SpectrometerDataStream"]
 	path = AVNDataTypes/SpectrometerDataStream
-	url = https://github.com/ska-sa/AVNSpectrometerDataStream.git
+	url = git@github.com/ska-sa/AVNSpectrometerDataStream.git
 [submodule "AVNUtilLibs/Timestamp"]
 	path = AVNUtilLibs/Timestamp
-	url = https://github.com/ska-sa/AVNTimestamp.git
+	url = git@github.com/ska-sa/AVNTimestamp.git
 [submodule "AVNUtilLibs/CoordinatePosition"]
 	path = AVNUtilLibs/CoordinatePosition
-	url = https://github.com/ska-sa/AVNCoordinatePosition.git
+	url = git@github.com/ska-sa/AVNCoordinatePosition.git
 [submodule "AVNAppLibs/KATCP"]
 	path = AVNAppLibs/KATCP
-	url = https://github.com/ska-sa/AVNKATCP.git
+	url = git@github.com/ska-sa/AVNKATCP.git
 [submodule "AVNUtilLibs/DirectoryContents"]
 	path = AVNUtilLibs/DirectoryContents
-	url = https://github.com/ska-sa/AVNDirectoryContents.git
+	url = git@github.com/ska-sa/AVNDirectoryContents.git
 [submodule "AVNUtilLibs/Filename"]
 	path = AVNUtilLibs/Filename
-	url = https://github.com/ska-sa/AVNFilename.git
+	url = git@github.com/ska-sa/AVNFilename.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,27 @@
 [submodule "AVNUtilLibs/Sockets"]
 	path = AVNUtilLibs/Sockets
-	url = git@github.com/ska-sa/AVNSockets.git
+	url = git@github.com:ska-sa/AVNSockets.git
 [submodule "AVNUtilLibs/DataStructures"]
 	path = AVNUtilLibs/DataStructures
-	url = git@github.com/ska-sa/AVNDataStructures.git
+	url = git@github.com:ska-sa/AVNDataStructures.git
 [submodule "AVNAppLibs/SocketStreamers"]
 	path = AVNAppLibs/SocketStreamers
-	url = git@github.com/ska-sa/AVNSocketStreamers.git
+	url = git@github.com:ska-sa/AVNSocketStreamers.git
 [submodule "AVNDataTypes/SpectrometerDataStream"]
 	path = AVNDataTypes/SpectrometerDataStream
-	url = git@github.com/ska-sa/AVNSpectrometerDataStream.git
+	url = git@github.com:ska-sa/AVNSpectrometerDataStream.git
 [submodule "AVNUtilLibs/Timestamp"]
 	path = AVNUtilLibs/Timestamp
-	url = git@github.com/ska-sa/AVNTimestamp.git
+	url = git@github.com:ska-sa/AVNTimestamp.git
 [submodule "AVNUtilLibs/CoordinatePosition"]
 	path = AVNUtilLibs/CoordinatePosition
-	url = git@github.com/ska-sa/AVNCoordinatePosition.git
+	url = git@github.com:ska-sa/AVNCoordinatePosition.git
 [submodule "AVNAppLibs/KATCP"]
 	path = AVNAppLibs/KATCP
-	url = git@github.com/ska-sa/AVNKATCP.git
+	url = git@github.com:ska-sa/AVNKATCP.git
 [submodule "AVNUtilLibs/DirectoryContents"]
 	path = AVNUtilLibs/DirectoryContents
-	url = git@github.com/ska-sa/AVNDirectoryContents.git
+	url = git@github.com:ska-sa/AVNDirectoryContents.git
 [submodule "AVNUtilLibs/Filename"]
 	path = AVNUtilLibs/Filename
-	url = git@github.com/ska-sa/AVNFilename.git
+	url = git@github.com:ska-sa/AVNFilename.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:10.13-slim
 
+# Replace sources.list with archive.debian.org
+RUN sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list \
+ && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y git \
     build-essential \
     cmake \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,9 @@
+# docker build -f Dockerfile-dev --no-cache -t roach2-dev .
+
+FROM roach2-base:latest
+
+WORKDIR /workspace
+COPY . .
+
+RUN cmake .
+RUN make

--- a/Dockerfile-dev-base
+++ b/Dockerfile-dev-base
@@ -1,0 +1,36 @@
+# docker build -f Dockerfile-dev-base --no-cache -t roach2-base .
+
+FROM debian:10.13-slim
+
+# Replace sources.list with archive.debian.org
+RUN sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list \
+ && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y git \
+    build-essential \
+    cmake \
+    libboost-system-dev \
+    libboost-thread-dev \
+    libboost-program-options-dev \
+    libboost-filesystem-dev \
+    libhdf5-dev \
+    python2.7 \
+    python-pip \
+    python-numpy
+
+RUN pip install katversion==0.9
+RUN pip install katcp==0.6.2
+
+WORKDIR /workspace
+RUN git clone https://github.com/ska-sa/casperfpga.git
+WORKDIR /workspace/casperfpga
+RUN git checkout v0.4.3
+RUN python setup.py install
+
+WORKDIR /workspace
+RUN git clone --recursive https://github.com/ska-sa/katcp_devel.git
+WORKDIR /workspace/katcp_devel
+# Change to KATCP v5.0
+RUN git checkout version-5.0
+RUN make
+RUN make -C katcp install

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -197,7 +197,7 @@ cHDF5FileWriter::cHDF5FileWriter(const string &strRecordingDirectory, uint32_t u
         m_oInitialValueSet.m_strObservationInformation = "";
 
         m_oInitialValueSet.m_i64TSObservedMaserName_us = 0;
-        sprintf(m_oInitialValueSet.m_chaObservedMaserName, "");
+        sprintf(m_oInitialValueSet.m_chaVObservedMaserName, "");
         sprintf(m_oInitialValueSet.m_chaObservedMaserNameStatus, "0");
 
         m_oInitialValueSet.m_i64TSObservedMaserVlsr_us = 0;
@@ -532,12 +532,12 @@ void cHDF5FileWriter::getNextFrame_callback(const std::vector<int> &vi32Chan0, c
 
         if (m_oInitialValueSet.m_i64TSObservedMaserName_us)
             m_pHDF5File->addObservedMaserName(m_oInitialValueSet.m_i64TSObservedMaserName_us,
-                                              m_oInitialValueSet.m_strObservedMaserName,
+                                              m_oInitialValueSet.m_chaVObservedMaserName,
                                               m_oInitialValueSet.m_chaObservedMaserNameStatus);
 
         if (m_oInitialValueSet.m_i64TSObservedMaserVlsr_us)
             m_pHDF5File->addObservedMaserVlsr(m_oInitialValueSet.m_i64TSObservedMaserVlsr_us,
-                                              m_oInitialValueSet.m_dObservedMaserVlsr_km_s,
+                                              m_oInitialValueSet.m_dVObservedMaserVlsr_km_s,
                                               m_oInitialValueSet.m_chaObservedMaserVlsrStatus);
 
         setState(RECORDING);
@@ -1092,7 +1092,7 @@ void cHDF5FileWriter::observedMaserName_callback(int64_t i64Timestamp_us, const 
     {
         boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
         m_oInitialValueSet.m_i64TSObservedMaserName_us = i64Timestamp_us;
-        sprintf(m_oInitialValueSet.m_chaObservedMaserName, "%s", strObservedMaserName.c_str());
+        sprintf(m_oInitialValueSet.m_chaVObservedMaserName, "%s", strObservedMaserName.c_str());
         sprintf(m_oInitialValueSet.m_chaObservedMaserNameStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
@@ -1105,11 +1105,11 @@ void cHDF5FileWriter::observedMaserVlsr_callback(int64_t i64Timestamp_us, double
     {
         boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
         m_oInitialValueSet.m_i64TSObservedMaserVlsr_us = i64Timestamp_us;
-        m_oInitialValueSet.m_dObservedMaserVlsr_km_s = dObservedMaserVlsr_km_s;
+        m_oInitialValueSet.m_dVObservedMaserVlsr_km_s = dObservedMaserVlsr_km_s;
         sprintf(m_oInitialValueSet.m_chaObservedMaserVlsrStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addTemperature(i64Timestamp_us, m_dObservedMaserVlsr_km_s, strStatus);
+        m_pHDF5File->addTemperature(i64Timestamp_us, m_dVObservedMaserVlsr_km_s, strStatus);
 }
 
 void cHDF5FileWriter::rNoiseDiode5GHzInputSource_callback(int64_t i64Timestamp_us, const string &strInputSource, const string &strStatus)

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -78,6 +78,22 @@ cHDF5FileWriter::cHDF5FileWriter(const string &strRecordingDirectory, uint32_t u
         for (int i = 0; i < 30; i++)
             m_oInitialValueSet.m_aPointingModel[i] = 0;
 
+        m_oInitialValueSet.m_i64TSSkyRequestedRaOffset_us = 0;
+        m_oInitialValueSet.m_dVSkyRequestedRaOffset_deg = 0;
+        sprintf(m_oInitialValueSet.m_chaSkyRequestedRaOffsetStatus, "0");
+
+        m_oInitialValueSet.m_i64TSSkyRequestedDecOffset_us = 0;
+        m_oInitialValueSet.m_dVSkyRequestedDecOffset_deg = 0;
+        sprintf(m_oInitialValueSet.m_chaSkyRequestedDecOffsetStatus, "0");
+
+        m_oInitialValueSet.m_i64TSSkyRequestedAzOffset_us = 0;
+        m_oInitialValueSet.m_dVSkyRequestedAzOffset_deg = 0;
+        sprintf(m_oInitialValueSet.m_chaSkyRequestedAzOffsetStatus, "0");
+
+        m_oInitialValueSet.m_i64TSSkyRequestedElOffset_us = 0;
+        m_oInitialValueSet.m_dVSkyRequestedElOffset_deg = 0;
+        sprintf(m_oInitialValueSet.m_chaSkyRequestedElOffsetStatus, "0");
+
         m_oInitialValueSet.m_i64TSAntennaStatus_us = 0;
         sprintf(m_oInitialValueSet.m_chaVAntennaStatus, "idle");
         sprintf(m_oInitialValueSet.m_chaAntennaStatusStatus, "0");
@@ -409,6 +425,22 @@ void cHDF5FileWriter::getNextFrame_callback(const std::vector<int> &vi32Chan0, c
                                         m_oInitialValueSet.m_chaSkyActualElevStatus);
         for (int i = 0; i < 30; i++)
             m_pHDF5File->addPointingModelParameter(i, m_oInitialValueSet.m_aPointingModel[i]);
+        if (m_oInitialValueSet.m_i64TSSkyRequestedRaOffset_us)
+            m_pHDF5File->addSkyRequestedRaOffset(m_oInitialValueSet.m_i64TSSkyRequestedRaOffset_us,
+                                                 m_oInitialValueSet.m_dVSkyRequestedRaOffset_deg,
+                                                 m_oInitialValueSet.m_chaSkyRequestedRaOffsetStatus);
+        if (m_oInitialValueSet.m_i64TSSkyRequestedDecOffset_us)
+            m_pHDF5File->addSkyRequestedDecOffset(m_oInitialValueSet.m_i64TSSkyRequestedDecOffset_us,
+                                                  m_oInitialValueSet.m_dVSkyRequestedDecOffset_deg,
+                                                  m_oInitialValueSet.m_chaSkyRequestedDecOffsetStatus);
+        if (m_oInitialValueSet.m_i64TSSkyRequestedAzOffset_us)
+            m_pHDF5File->addSkyRequestedAzOffset(m_oInitialValueSet.m_i64TSSkyRequestedAzOffset_us,
+                                                 m_oInitialValueSet.m_dVSkyRequestedAzOffset_deg,
+                                                 m_oInitialValueSet.m_chaSkyRequestedAzOffsetStatus);
+        if (m_oInitialValueSet.m_i64TSSkyRequestedElOffset_us)
+            m_pHDF5File->addSkyRequestedElOffset(m_oInitialValueSet.m_i64TSSkyRequestedElOffset_us,
+                                                 m_oInitialValueSet.m_dVSkyRequestedElOffset_deg,
+                                                 m_oInitialValueSet.m_chaSkyRequestedElOffsetStatus);
         if (m_oInitialValueSet.m_i64TSAntennaStatus_us)
             m_pHDF5File->addAntennaStatus(m_oInitialValueSet.m_i64TSAntennaStatus_us,
                                           m_oInitialValueSet.m_chaVAntennaStatus,
@@ -1050,6 +1082,58 @@ void cHDF5FileWriter::pointingModel_callback(uint8_t ui8ParameterNumber, double 
     }
     if (getState() == RECORDING)
         m_pHDF5File->addPointingModelParameter(ui8ParameterNumber - 1, dParameterValue);
+}
+
+void cHDF5FileWriter::skyRequestedRaOffset_callback(int64_t i64Timestamp_us,double dRightAscensionOffset_deg, const string &strStatus)
+{
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSSkyRequestedRaOffset_us)
+    {
+        boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
+        m_oInitialValueSet.m_i64TSSkyRequestedRaOffset_us = i64Timestamp_us;
+        m_oInitialValueSet.m_dVSkyRequestedRaOffset_deg = dRightAscensionOffset_deg;
+        sprintf(m_oInitialValueSet.m_chaSkyRequestedRaOffsetStatus, "%s", strStatus.c_str());
+    }
+    if(getState() == RECORDING)
+        m_pHDF5File->addSkyRequestedAz(i64Timestamp_us, dRightAscensionOffset_deg, strStatus);
+}
+
+void cHDF5FileWriter::skyRequestedDecOffset_callback(int64_t i64Timestamp_us,double dDeclinationOffset_deg, const string &strStatus)
+{
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSSkyRequestedDecOffset_us)
+    {
+        boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
+        m_oInitialValueSet.m_i64TSSkyRequestedDecOffset_us = i64Timestamp_us;
+        m_oInitialValueSet.m_dVSkyRequestedDecOffset_deg = dDeclinationOffset_deg;
+        sprintf(m_oInitialValueSet.m_chaSkyRequestedDecOffsetStatus, "%s", strStatus.c_str());
+    }
+    if(getState() == RECORDING)
+        m_pHDF5File->addSkyRequestedAz(i64Timestamp_us, dDeclinationOffset_deg, strStatus);
+}
+
+void cHDF5FileWriter::skyRequestedAzOffset_callback(int64_t i64Timestamp_us,double dAzimuthOffset_deg, const string &strStatus)
+{
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSSkyRequestedAzOffset_us)
+    {
+        boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
+        m_oInitialValueSet.m_i64TSSkyRequestedAzOffset_us = i64Timestamp_us;
+        m_oInitialValueSet.m_dVSkyRequestedAzOffset_deg = dAzimuthOffset_deg;
+        sprintf(m_oInitialValueSet.m_chaSkyRequestedAzOffsetStatus, "%s", strStatus.c_str());
+    }
+    if(getState() == RECORDING)
+        m_pHDF5File->addSkyRequestedAz(i64Timestamp_us, dAzimuthOffset_deg, strStatus);
+}
+
+void cHDF5FileWriter::skyRequestedElOffset_callback(int64_t i64Timestamp_us,double dElevationOffset_deg, const string &strStatus)
+{
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSSkyRequestedElOffset_us)
+    {
+        boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
+        m_oInitialValueSet.m_i64TSSkyRequestedElOffset_us = i64Timestamp_us;
+        m_oInitialValueSet.m_dVSkyRequestedElOffset_deg = dElevationOffset_deg;
+        sprintf(m_oInitialValueSet.m_chaSkyRequestedElOffsetStatus, "%s", strStatus.c_str());
+    }
+    if(getState() == RECORDING)
+        m_pHDF5File->addSkyRequestedAz(i64Timestamp_us, dElevationOffset_deg, strStatus);
 }
 
 void cHDF5FileWriter::antennaStatus_callback(int64_t i64Timestamp_us, const string &strAntennaStatus, const string &strStatus)

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -195,8 +195,14 @@ cHDF5FileWriter::cHDF5FileWriter(const string &strRecordingDirectory, uint32_t u
         // PJP
         m_oInitialValueSet.m_dAntennaBeamwidth_deg = 0.0;
         m_oInitialValueSet.m_strObservationInformation = "";
-        m_oInitialValueSet.m_strObservedMaserName = "";
-        m_oInitialValueSet.m_dObservedMaserVlsr_km_s = 0.0;
+
+        m_oInitialValueSet.m_i64TSObservedMaserName_us = 0;
+        sprintf(m_oInitialValueSet.m_chaObservedMaserName, "");
+        sprintf(m_oInitialValueSet.m_chaObservedMaserNameStatus, "0");
+
+        m_oInitialValueSet.m_i64TSObservedMaserVlsr_us = 0;
+        m_oInitialValueSet.m_dVObservedMaserVlsr_km_s = 0;
+        sprintf(m_oInitialValueSet.m_chaObservedMaserVlsrStatus, "0");
     }
 }
 
@@ -524,11 +530,15 @@ void cHDF5FileWriter::getNextFrame_callback(const std::vector<int> &vi32Chan0, c
         if ("" != m_oInitialValueSet.m_strObservationInformation)
             m_pHDF5File->setObservationInfo(m_oInitialValueSet.m_strObservationInformation);
 
-        if ("" != m_oInitialValueSet.m_strObservedMaserName)
-            m_pHDF5File->addObservedMaserName(m_oInitialValueSet.m_strObservedMaserName);
+        if (m_oInitialValueSet.m_i64TSObservedMaserName_us)
+            m_pHDF5File->addObservedMaserName(m_oInitialValueSet.m_i64TSObservedMaserName_us,
+                                              m_oInitialValueSet.m_strObservedMaserName,
+                                              m_oInitialValueSet.m_chaObservedMaserNameStatus);
 
-        if (0.0 != m_oInitialValueSet.m_dObservedMaserVlsr_km_s)
-            m_pHDF5File->addObservedMaserVlsr(m_oInitialValueSet.m_dObservedMaserVlsr_km_s);
+        if (m_oInitialValueSet.m_i64TSObservedMaserVlsr_us)
+            m_pHDF5File->addObservedMaserVlsr(m_oInitialValueSet.m_i64TSObservedMaserVlsr_us,
+                                              m_oInitialValueSet.m_dObservedMaserVlsr_km_s,
+                                              m_oInitialValueSet.m_chaObservedMaserVlsrStatus);
 
         setState(RECORDING);
 
@@ -1078,16 +1088,28 @@ void cHDF5FileWriter::antennaBeamwidth_callback(int64_t i64Timestamp_us, const s
 
 void cHDF5FileWriter::observedMaserName_callback(int64_t i64Timestamp_us, const string &strObservedMaserName, const std::string &strStatus)
 {
-    m_oInitialValueSet.m_strObservedMaserName = strObservedMaserName;
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSObservedMaserName_us)
+    {
+        boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
+        m_oInitialValueSet.m_i64TSObservedMaserName_us = i64Timestamp_us;
+        sprintf(m_oInitialValueSet.m_chaObservedMaserName, "%s", strObservedMaserName.c_str());
+        sprintf(m_oInitialValueSet.m_chaObservedMaserNameStatus, "%s", strStatus.c_str());
+    }
     if(getState() == RECORDING)
-        m_pHDF5File->addObservedMaserName(m_oInitialValueSet.m_strObservedMaserName);
+        m_pHDF5File->addObservedMaserName(i64Timestamp_us, strObservedMaserName, strStatus);
 }
 
 void cHDF5FileWriter::observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus)
 {
-    m_oInitialValueSet.m_dObservedMaserVlsr_km_s = dObservedMaserVlsr_km_s;
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSObservedMaserVlsr_us)
+    {
+        boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
+        m_oInitialValueSet.m_i64TSObservedMaserVlsr_us = i64Timestamp_us;
+        m_oInitialValueSet.m_dObservedMaserVlsr_km_s = dObservedMaserVlsr_km_s;
+        sprintf(m_oInitialValueSet.m_chaObservedMaserVlsrStatus, "%s", strStatus.c_str());
+    }
     if(getState() == RECORDING)
-        m_pHDF5File->addObservedMaserVlsr(m_oInitialValueSet.m_dObservedMaserVlsr_km_s);
+        m_pHDF5File->addTemperature(i64Timestamp_us, m_dObservedMaserVlsr_km_s, strStatus);
 }
 
 void cHDF5FileWriter::rNoiseDiode5GHzInputSource_callback(int64_t i64Timestamp_us, const string &strInputSource, const string &strStatus)

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -1080,14 +1080,14 @@ void cHDF5FileWriter::observedMaserName_callback(int64_t i64Timestamp_us, const 
 {
     m_oInitialValueSet.m_strObservedMaserName = strObservedMaserName;
     if(getState() == RECORDING)
-        m_pHDF5File->setObservedMaserName(m_oInitialValueSet.m_strObservedMaserName);
+        m_pHDF5File->addObservedMaserName(m_oInitialValueSet.m_strObservedMaserName);
 }
 
 void cHDF5FileWriter::observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus)
 {
     m_oInitialValueSet.m_dObservedMaserVlsr_km_s = dObservedMaserVlsr_km_s;
     if(getState() == RECORDING)
-        m_pHDF5File->setObservedMaserVlsr(m_oInitialValueSet.m_dObservedMaserVlsr_km_s);
+        m_pHDF5File->addObservedMaserVlsr(m_oInitialValueSet.m_dObservedMaserVlsr_km_s);
 }
 
 void cHDF5FileWriter::rNoiseDiode5GHzInputSource_callback(int64_t i64Timestamp_us, const string &strInputSource, const string &strStatus)

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -215,6 +215,10 @@ cHDF5FileWriter::cHDF5FileWriter(const string &strRecordingDirectory, uint32_t u
         m_oInitialValueSet.m_i64TSObservedMaser_us = 0;
         m_oInitialValueSet.m_strObservedMaser = "";
         sprintf(m_oInitialValueSet.m_chaObservedMaserStatus, "0");
+
+        m_oInitialValueSet.m_i64TSObservationDetails_us = 0;
+        m_oInitialValueSet.m_strObservationDetails = "";
+        sprintf(m_oInitialValueSet.m_chaObservationDetailsStatus, "0");
     }
 }
 
@@ -562,6 +566,11 @@ void cHDF5FileWriter::getNextFrame_callback(const std::vector<int> &vi32Chan0, c
             m_pHDF5File->addObservedMaser(m_oInitialValueSet.m_i64TSObservedMaser_us,
                                           m_oInitialValueSet.m_strObservedMaser,
                                           m_oInitialValueSet.m_chaObservedMaserStatus);
+
+        if (m_oInitialValueSet.m_i64TSObservationDetails_us)
+            m_pHDF5File->addObservationDetails(m_oInitialValueSet.m_i64TSObservationDetails_us,
+                                               m_oInitialValueSet.m_strObservationDetails,
+                                               m_oInitialValueSet.m_chaObservationDetailsStatus);
 
         setState(RECORDING);
 
@@ -1173,6 +1182,19 @@ void cHDF5FileWriter::observedMaser_callback(int64_t i64Timestamp_us, const stri
     }
     if(getState() == RECORDING)
         m_pHDF5File->addObservedMaser(i64Timestamp_us, strObservedMaser, strStatus);
+}
+
+void cHDF5FileWriter::observationDetails_callback(int64_t i64Timestamp_us, const string &strObservationDetails, const std::string &strStatus)
+{
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSObservationDetails_us)
+    {
+        boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
+        m_oInitialValueSet.m_i64TSObservationDetails_us = i64Timestamp_us;
+        m_oInitialValueSet.m_strObservationDetails = strObservationDetails;
+        sprintf(m_oInitialValueSet.m_chaObservationDetailsStatus, "%s", strStatus.c_str());
+    }
+    if(getState() == RECORDING)
+        m_pHDF5File->addObservationDetails(i64Timestamp_us, strObservationDetails, strStatus);
 }
 
 void cHDF5FileWriter::rNoiseDiode5GHzInputSource_callback(int64_t i64Timestamp_us, const string &strInputSource, const string &strStatus)

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -1109,7 +1109,7 @@ void cHDF5FileWriter::observedMaserVlsr_callback(int64_t i64Timestamp_us, double
         sprintf(m_oInitialValueSet.m_chaObservedMaserVlsrStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addObservedMaserVlsr(i64Timestamp_us, m_dVObservedMaserVlsr_km_s, strStatus);
+        m_pHDF5File->addObservedMaserVlsr(i64Timestamp_us, dObservedMaserVlsr_km_s, strStatus);
 }
 
 void cHDF5FileWriter::rNoiseDiode5GHzInputSource_callback(int64_t i64Timestamp_us, const string &strInputSource, const string &strStatus)

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -212,13 +212,9 @@ cHDF5FileWriter::cHDF5FileWriter(const string &strRecordingDirectory, uint32_t u
         m_oInitialValueSet.m_dAntennaBeamwidth_deg = 0.0;
         m_oInitialValueSet.m_strAntennaInfo = "";
 
-        m_oInitialValueSet.m_i64TSObservedMaserName_us = 0;
-        sprintf(m_oInitialValueSet.m_chaVObservedMaserName, "");
-        sprintf(m_oInitialValueSet.m_chaObservedMaserNameStatus, "0");
-
-        m_oInitialValueSet.m_i64TSObservedMaserVlsr_us = 0;
-        m_oInitialValueSet.m_dVObservedMaserVlsr_km_s = 0;
-        sprintf(m_oInitialValueSet.m_chaObservedMaserVlsrStatus, "0");
+        m_oInitialValueSet.m_i64TSObservedMaser_us = 0;
+        m_oInitialValueSet.m_strObservedMaser = "";
+        sprintf(m_oInitialValueSet.m_chaObservedMaserStatus, "0");
     }
 }
 
@@ -562,15 +558,10 @@ void cHDF5FileWriter::getNextFrame_callback(const std::vector<int> &vi32Chan0, c
         if ("" != m_oInitialValueSet.m_strAntennaInfo)
             m_pHDF5File->setAntennaInfo(m_oInitialValueSet.m_strAntennaInfo);
 
-        if (m_oInitialValueSet.m_i64TSObservedMaserName_us)
-            m_pHDF5File->addObservedMaserName(m_oInitialValueSet.m_i64TSObservedMaserName_us,
-                                              m_oInitialValueSet.m_chaVObservedMaserName,
-                                              m_oInitialValueSet.m_chaObservedMaserNameStatus);
-
-        if (m_oInitialValueSet.m_i64TSObservedMaserVlsr_us)
-            m_pHDF5File->addObservedMaserVlsr(m_oInitialValueSet.m_i64TSObservedMaserVlsr_us,
-                                              m_oInitialValueSet.m_dVObservedMaserVlsr_km_s,
-                                              m_oInitialValueSet.m_chaObservedMaserVlsrStatus);
+        if (m_oInitialValueSet.m_i64TSObservedMaser_us)
+            m_pHDF5File->addObservedMaser(m_oInitialValueSet.m_i64TSObservedMaser_us,
+                                          m_oInitialValueSet.m_strObservedMaser,
+                                          m_oInitialValueSet.m_chaObservedMaserStatus);
 
         setState(RECORDING);
 
@@ -1171,30 +1162,17 @@ void cHDF5FileWriter::antennaBeamwidth_callback(int64_t i64Timestamp_us, const s
     }
 }
 
-void cHDF5FileWriter::observedMaserName_callback(int64_t i64Timestamp_us, const string &strObservedMaserName, const std::string &strStatus)
+void cHDF5FileWriter::observedMaser_callback(int64_t i64Timestamp_us, const string &strObservedMaser, const std::string &strStatus)
 {
-    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSObservedMaserName_us)
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSObservedMaser_us)
     {
         boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
-        m_oInitialValueSet.m_i64TSObservedMaserName_us = i64Timestamp_us;
-        sprintf(m_oInitialValueSet.m_chaVObservedMaserName, "%s", strObservedMaserName.c_str());
-        sprintf(m_oInitialValueSet.m_chaObservedMaserNameStatus, "%s", strStatus.c_str());
+        m_oInitialValueSet.m_i64TSObservedMaser_us = i64Timestamp_us;
+        m_oInitialValueSet.m_strObservedMaser = strObservedMaser;
+        sprintf(m_oInitialValueSet.m_chaObservedMaserStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addObservedMaserName(i64Timestamp_us, strObservedMaserName, strStatus);
-}
-
-void cHDF5FileWriter::observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus)
-{
-    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSObservedMaserVlsr_us)
-    {
-        boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
-        m_oInitialValueSet.m_i64TSObservedMaserVlsr_us = i64Timestamp_us;
-        m_oInitialValueSet.m_dVObservedMaserVlsr_km_s = dObservedMaserVlsr_km_s;
-        sprintf(m_oInitialValueSet.m_chaObservedMaserVlsrStatus, "%s", strStatus.c_str());
-    }
-    if(getState() == RECORDING)
-        m_pHDF5File->addObservedMaserVlsr(i64Timestamp_us, dObservedMaserVlsr_km_s, strStatus);
+        m_pHDF5File->addObservedMaser(i64Timestamp_us, strObservedMaser, strStatus);
 }
 
 void cHDF5FileWriter::rNoiseDiode5GHzInputSource_callback(int64_t i64Timestamp_us, const string &strInputSource, const string &strStatus)

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -195,6 +195,8 @@ cHDF5FileWriter::cHDF5FileWriter(const string &strRecordingDirectory, uint32_t u
         // PJP
         m_oInitialValueSet.m_dAntennaBeamwidth_deg = 0.0;
         m_oInitialValueSet.m_strObservationInformation = "";
+        m_oInitialValueSet.m_strObservedMaserName = "";
+        m_oInitialValueSet.m_dObservedMaserVlsr_km_s = 0.0;
     }
 }
 
@@ -521,6 +523,12 @@ void cHDF5FileWriter::getNextFrame_callback(const std::vector<int> &vi32Chan0, c
 
         if ("" != m_oInitialValueSet.m_strObservationInformation)
             m_pHDF5File->setObservationInfo(m_oInitialValueSet.m_strObservationInformation);
+
+        if ("" != m_oInitialValueSet.m_strObservedMaserName)
+            m_pHDF5File->addObservedMaserName(m_oInitialValueSet.m_strObservedMaserName);
+
+        if (0.0 != m_oInitialValueSet.m_dObservedMaserVlsr_km_s)
+            m_pHDF5File->addObservedMaserVlsr(m_oInitialValueSet.m_dObservedMaserVlsr_km_s);
 
         setState(RECORDING);
 
@@ -1066,6 +1074,20 @@ void cHDF5FileWriter::antennaBeamwidth_callback(int64_t i64Timestamp_us, const s
     {
         m_pHDF5File->setAntennaBeamwidth(m_oInitialValueSet.m_dAntennaBeamwidth_deg);
     }
+}
+
+void cHDF5FileWriter::observedMaserName_callback(int64_t i64Timestamp_us, const string &strObservedMaserName, const std::string &strStatus)
+{
+    m_oInitialValueSet.m_strObservedMaserName = strObservedMaserName;
+    if(getState() == RECORDING)
+        m_pHDF5File->setObservedMaserName(m_oInitialValueSet.m_strObservedMaserName);
+}
+
+void cHDF5FileWriter::observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus)
+{
+    m_oInitialValueSet.m_dObservedMaserVlsr_km_s = dObservedMaserVlsr_km_s;
+    if(getState() == RECORDING)
+        m_pHDF5File->setObservedMaserVlsr(m_oInitialValueSet.m_dObservedMaserVlsr_km_s);
 }
 
 void cHDF5FileWriter::rNoiseDiode5GHzInputSource_callback(int64_t i64Timestamp_us, const string &strInputSource, const string &strStatus)

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -78,21 +78,21 @@ cHDF5FileWriter::cHDF5FileWriter(const string &strRecordingDirectory, uint32_t u
         for (int i = 0; i < 30; i++)
             m_oInitialValueSet.m_aPointingModel[i] = 0;
 
-        m_oInitialValueSet.m_i64TSSkyRequestedRaOffset_us = 0;
-        m_oInitialValueSet.m_dVSkyRequestedRaOffset_deg = 0;
-        sprintf(m_oInitialValueSet.m_chaSkyRequestedRaOffsetStatus, "0");
+        m_oInitialValueSet.m_i64TSRequestedRaOffset_us = 0;
+        m_oInitialValueSet.m_dVRequestedRaOffset_deg = 0;
+        sprintf(m_oInitialValueSet.m_chaRequestedRaOffsetStatus, "0");
 
-        m_oInitialValueSet.m_i64TSSkyRequestedDecOffset_us = 0;
-        m_oInitialValueSet.m_dVSkyRequestedDecOffset_deg = 0;
-        sprintf(m_oInitialValueSet.m_chaSkyRequestedDecOffsetStatus, "0");
+        m_oInitialValueSet.m_i64TSRequestedDecOffset_us = 0;
+        m_oInitialValueSet.m_dVRequestedDecOffset_deg = 0;
+        sprintf(m_oInitialValueSet.m_chaRequestedDecOffsetStatus, "0");
 
-        m_oInitialValueSet.m_i64TSSkyRequestedAzOffset_us = 0;
-        m_oInitialValueSet.m_dVSkyRequestedAzOffset_deg = 0;
-        sprintf(m_oInitialValueSet.m_chaSkyRequestedAzOffsetStatus, "0");
+        m_oInitialValueSet.m_i64TSRequestedAzOffset_us = 0;
+        m_oInitialValueSet.m_dVRequestedAzOffset_deg = 0;
+        sprintf(m_oInitialValueSet.m_chaRequestedAzOffsetStatus, "0");
 
-        m_oInitialValueSet.m_i64TSSkyRequestedElOffset_us = 0;
-        m_oInitialValueSet.m_dVSkyRequestedElOffset_deg = 0;
-        sprintf(m_oInitialValueSet.m_chaSkyRequestedElOffsetStatus, "0");
+        m_oInitialValueSet.m_i64TSRequestedElOffset_us = 0;
+        m_oInitialValueSet.m_dVRequestedElOffset_deg = 0;
+        sprintf(m_oInitialValueSet.m_chaRequestedElOffsetStatus, "0");
 
         m_oInitialValueSet.m_i64TSAntennaStatus_us = 0;
         sprintf(m_oInitialValueSet.m_chaVAntennaStatus, "idle");
@@ -425,22 +425,22 @@ void cHDF5FileWriter::getNextFrame_callback(const std::vector<int> &vi32Chan0, c
                                         m_oInitialValueSet.m_chaSkyActualElevStatus);
         for (int i = 0; i < 30; i++)
             m_pHDF5File->addPointingModelParameter(i, m_oInitialValueSet.m_aPointingModel[i]);
-        if (m_oInitialValueSet.m_i64TSSkyRequestedRaOffset_us)
-            m_pHDF5File->addSkyRequestedRaOffset(m_oInitialValueSet.m_i64TSSkyRequestedRaOffset_us,
-                                                 m_oInitialValueSet.m_dVSkyRequestedRaOffset_deg,
-                                                 m_oInitialValueSet.m_chaSkyRequestedRaOffsetStatus);
-        if (m_oInitialValueSet.m_i64TSSkyRequestedDecOffset_us)
-            m_pHDF5File->addSkyRequestedDecOffset(m_oInitialValueSet.m_i64TSSkyRequestedDecOffset_us,
-                                                  m_oInitialValueSet.m_dVSkyRequestedDecOffset_deg,
-                                                  m_oInitialValueSet.m_chaSkyRequestedDecOffsetStatus);
-        if (m_oInitialValueSet.m_i64TSSkyRequestedAzOffset_us)
-            m_pHDF5File->addSkyRequestedAzOffset(m_oInitialValueSet.m_i64TSSkyRequestedAzOffset_us,
-                                                 m_oInitialValueSet.m_dVSkyRequestedAzOffset_deg,
-                                                 m_oInitialValueSet.m_chaSkyRequestedAzOffsetStatus);
-        if (m_oInitialValueSet.m_i64TSSkyRequestedElOffset_us)
-            m_pHDF5File->addSkyRequestedElOffset(m_oInitialValueSet.m_i64TSSkyRequestedElOffset_us,
-                                                 m_oInitialValueSet.m_dVSkyRequestedElOffset_deg,
-                                                 m_oInitialValueSet.m_chaSkyRequestedElOffsetStatus);
+        if (m_oInitialValueSet.m_i64TSRequestedRaOffset_us)
+            m_pHDF5File->addRequestedRaOffset(m_oInitialValueSet.m_i64TSRequestedRaOffset_us,
+                                              m_oInitialValueSet.m_dVRequestedRaOffset_deg,
+                                              m_oInitialValueSet.m_chaRequestedRaOffsetStatus);
+        if (m_oInitialValueSet.m_i64TSRequestedDecOffset_us)
+            m_pHDF5File->addRequestedDecOffset(m_oInitialValueSet.m_i64TSRequestedDecOffset_us,
+                                               m_oInitialValueSet.m_dVRequestedDecOffset_deg,
+                                               m_oInitialValueSet.m_chaRequestedDecOffsetStatus);
+        if (m_oInitialValueSet.m_i64TSRequestedAzOffset_us)
+            m_pHDF5File->addRequestedAzOffset(m_oInitialValueSet.m_i64TSRequestedAzOffset_us,
+                                              m_oInitialValueSet.m_dVRequestedAzOffset_deg,
+                                              m_oInitialValueSet.m_chaRequestedAzOffsetStatus);
+        if (m_oInitialValueSet.m_i64TSRequestedElOffset_us)
+            m_pHDF5File->addRequestedElOffset(m_oInitialValueSet.m_i64TSRequestedElOffset_us,
+                                              m_oInitialValueSet.m_dVRequestedElOffset_deg,
+                                              m_oInitialValueSet.m_chaRequestedElOffsetStatus);
         if (m_oInitialValueSet.m_i64TSAntennaStatus_us)
             m_pHDF5File->addAntennaStatus(m_oInitialValueSet.m_i64TSAntennaStatus_us,
                                           m_oInitialValueSet.m_chaVAntennaStatus,
@@ -1084,56 +1084,56 @@ void cHDF5FileWriter::pointingModel_callback(uint8_t ui8ParameterNumber, double 
         m_pHDF5File->addPointingModelParameter(ui8ParameterNumber - 1, dParameterValue);
 }
 
-void cHDF5FileWriter::skyRequestedRaOffset_callback(int64_t i64Timestamp_us,double dRightAscensionOffset_deg, const string &strStatus)
+void cHDF5FileWriter::RequestedRaOffset_callback(int64_t i64Timestamp_us,double dRightAscensionOffset_deg, const string &strStatus)
 {
-    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSSkyRequestedRaOffset_us)
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSRequestedRaOffset_us)
     {
         boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
-        m_oInitialValueSet.m_i64TSSkyRequestedRaOffset_us = i64Timestamp_us;
-        m_oInitialValueSet.m_dVSkyRequestedRaOffset_deg = dRightAscensionOffset_deg;
-        sprintf(m_oInitialValueSet.m_chaSkyRequestedRaOffsetStatus, "%s", strStatus.c_str());
+        m_oInitialValueSet.m_i64TSRequestedRaOffset_us = i64Timestamp_us;
+        m_oInitialValueSet.m_dVRequestedRaOffset_deg = dRightAscensionOffset_deg;
+        sprintf(m_oInitialValueSet.m_chaRequestedRaOffsetStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addSkyRequestedRaOffset(i64Timestamp_us, dRightAscensionOffset_deg, strStatus);
+        m_pHDF5File->addRequestedRaOffset(i64Timestamp_us, dRightAscensionOffset_deg, strStatus);
 }
 
-void cHDF5FileWriter::skyRequestedDecOffset_callback(int64_t i64Timestamp_us,double dDeclinationOffset_deg, const string &strStatus)
+void cHDF5FileWriter::RequestedDecOffset_callback(int64_t i64Timestamp_us,double dDeclinationOffset_deg, const string &strStatus)
 {
-    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSSkyRequestedDecOffset_us)
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSRequestedDecOffset_us)
     {
         boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
-        m_oInitialValueSet.m_i64TSSkyRequestedDecOffset_us = i64Timestamp_us;
-        m_oInitialValueSet.m_dVSkyRequestedDecOffset_deg = dDeclinationOffset_deg;
-        sprintf(m_oInitialValueSet.m_chaSkyRequestedDecOffsetStatus, "%s", strStatus.c_str());
+        m_oInitialValueSet.m_i64TSRequestedDecOffset_us = i64Timestamp_us;
+        m_oInitialValueSet.m_dVRequestedDecOffset_deg = dDeclinationOffset_deg;
+        sprintf(m_oInitialValueSet.m_chaRequestedDecOffsetStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addSkyRequestedDecOffset(i64Timestamp_us, dDeclinationOffset_deg, strStatus);
+        m_pHDF5File->addRequestedDecOffset(i64Timestamp_us, dDeclinationOffset_deg, strStatus);
 }
 
-void cHDF5FileWriter::skyRequestedAzOffset_callback(int64_t i64Timestamp_us,double dAzimuthOffset_deg, const string &strStatus)
+void cHDF5FileWriter::RequestedAzOffset_callback(int64_t i64Timestamp_us,double dAzimuthOffset_deg, const string &strStatus)
 {
-    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSSkyRequestedAzOffset_us)
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSRequestedAzOffset_us)
     {
         boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
-        m_oInitialValueSet.m_i64TSSkyRequestedAzOffset_us = i64Timestamp_us;
-        m_oInitialValueSet.m_dVSkyRequestedAzOffset_deg = dAzimuthOffset_deg;
-        sprintf(m_oInitialValueSet.m_chaSkyRequestedAzOffsetStatus, "%s", strStatus.c_str());
+        m_oInitialValueSet.m_i64TSRequestedAzOffset_us = i64Timestamp_us;
+        m_oInitialValueSet.m_dVRequestedAzOffset_deg = dAzimuthOffset_deg;
+        sprintf(m_oInitialValueSet.m_chaRequestedAzOffsetStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addSkyRequestedAzOffset(i64Timestamp_us, dAzimuthOffset_deg, strStatus);
+        m_pHDF5File->addRequestedAzOffset(i64Timestamp_us, dAzimuthOffset_deg, strStatus);
 }
 
-void cHDF5FileWriter::skyRequestedElOffset_callback(int64_t i64Timestamp_us,double dElevationOffset_deg, const string &strStatus)
+void cHDF5FileWriter::RequestedElOffset_callback(int64_t i64Timestamp_us,double dElevationOffset_deg, const string &strStatus)
 {
-    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSSkyRequestedElOffset_us)
+    if (i64Timestamp_us > m_oInitialValueSet.m_i64TSRequestedElOffset_us)
     {
         boost::unique_lock<boost::shared_mutex> oLock(m_oMutex);
-        m_oInitialValueSet.m_i64TSSkyRequestedElOffset_us = i64Timestamp_us;
-        m_oInitialValueSet.m_dVSkyRequestedElOffset_deg = dElevationOffset_deg;
-        sprintf(m_oInitialValueSet.m_chaSkyRequestedElOffsetStatus, "%s", strStatus.c_str());
+        m_oInitialValueSet.m_i64TSRequestedElOffset_us = i64Timestamp_us;
+        m_oInitialValueSet.m_dVRequestedElOffset_deg = dElevationOffset_deg;
+        sprintf(m_oInitialValueSet.m_chaRequestedElOffsetStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addSkyRequestedElOffset(i64Timestamp_us, dElevationOffset_deg, strStatus);
+        m_pHDF5File->addRequestedElOffset(i64Timestamp_us, dElevationOffset_deg, strStatus);
 }
 
 void cHDF5FileWriter::antennaStatus_callback(int64_t i64Timestamp_us, const string &strAntennaStatus, const string &strStatus)

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -1094,7 +1094,7 @@ void cHDF5FileWriter::skyRequestedRaOffset_callback(int64_t i64Timestamp_us,doub
         sprintf(m_oInitialValueSet.m_chaSkyRequestedRaOffsetStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addSkyRequestedAz(i64Timestamp_us, dRightAscensionOffset_deg, strStatus);
+        m_pHDF5File->addSkyRequestedRaOffset(i64Timestamp_us, dRightAscensionOffset_deg, strStatus);
 }
 
 void cHDF5FileWriter::skyRequestedDecOffset_callback(int64_t i64Timestamp_us,double dDeclinationOffset_deg, const string &strStatus)
@@ -1107,7 +1107,7 @@ void cHDF5FileWriter::skyRequestedDecOffset_callback(int64_t i64Timestamp_us,dou
         sprintf(m_oInitialValueSet.m_chaSkyRequestedDecOffsetStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addSkyRequestedAz(i64Timestamp_us, dDeclinationOffset_deg, strStatus);
+        m_pHDF5File->addSkyRequestedDecOffset(i64Timestamp_us, dDeclinationOffset_deg, strStatus);
 }
 
 void cHDF5FileWriter::skyRequestedAzOffset_callback(int64_t i64Timestamp_us,double dAzimuthOffset_deg, const string &strStatus)
@@ -1120,7 +1120,7 @@ void cHDF5FileWriter::skyRequestedAzOffset_callback(int64_t i64Timestamp_us,doub
         sprintf(m_oInitialValueSet.m_chaSkyRequestedAzOffsetStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addSkyRequestedAz(i64Timestamp_us, dAzimuthOffset_deg, strStatus);
+        m_pHDF5File->addSkyRequestedAzOffset(i64Timestamp_us, dAzimuthOffset_deg, strStatus);
 }
 
 void cHDF5FileWriter::skyRequestedElOffset_callback(int64_t i64Timestamp_us,double dElevationOffset_deg, const string &strStatus)
@@ -1133,7 +1133,7 @@ void cHDF5FileWriter::skyRequestedElOffset_callback(int64_t i64Timestamp_us,doub
         sprintf(m_oInitialValueSet.m_chaSkyRequestedElOffsetStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addSkyRequestedAz(i64Timestamp_us, dElevationOffset_deg, strStatus);
+        m_pHDF5File->addSkyRequestedElOffset(i64Timestamp_us, dElevationOffset_deg, strStatus);
 }
 
 void cHDF5FileWriter::antennaStatus_callback(int64_t i64Timestamp_us, const string &strAntennaStatus, const string &strStatus)

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -210,7 +210,7 @@ cHDF5FileWriter::cHDF5FileWriter(const string &strRecordingDirectory, uint32_t u
 
         // PJP
         m_oInitialValueSet.m_dAntennaBeamwidth_deg = 0.0;
-        m_oInitialValueSet.m_strObservationInformation = "";
+        m_oInitialValueSet.m_strAntennaInfo = "";
 
         m_oInitialValueSet.m_i64TSObservedMaserName_us = 0;
         sprintf(m_oInitialValueSet.m_chaVObservedMaserName, "");
@@ -559,8 +559,8 @@ void cHDF5FileWriter::getNextFrame_callback(const std::vector<int> &vi32Chan0, c
         if (m_oInitialValueSet.m_dAntennaBeamwidth_deg)
             m_pHDF5File->setAntennaBeamwidth(m_oInitialValueSet.m_dAntennaBeamwidth_deg);
 
-        if ("" != m_oInitialValueSet.m_strObservationInformation)
-            m_pHDF5File->setObservationInfo(m_oInitialValueSet.m_strObservationInformation);
+        if ("" != m_oInitialValueSet.m_strAntennaInfo)
+            m_pHDF5File->setAntennaInfo(m_oInitialValueSet.m_strAntennaInfo);
 
         if (m_oInitialValueSet.m_i64TSObservedMaserName_us)
             m_pHDF5File->addObservedMaserName(m_oInitialValueSet.m_i64TSObservedMaserName_us,
@@ -1153,11 +1153,12 @@ void cHDF5FileWriter::appliedPointingModel_callback(const string &strModelName, 
 }
 */
 
-void cHDF5FileWriter::observationInfo_callback(const string &strObservationInfo)
+void cHDF5FileWriter::antennaInfo_callback(int64_t i64Timestamp_us, const string &strAntennaInfo, const string &strStatus)
 {
-    m_oInitialValueSet.m_strObservationInformation = strObservationInfo;
-   if(getState() == RECORDING)
-        m_pHDF5File->setObservationInfo(m_oInitialValueSet.m_strObservationInformation);
+    m_oInitialValueSet.m_strAntennaInfo = strAntennaInfo;
+
+    if(getState() == RECORDING)
+        m_pHDF5File->setAntennaInfo(m_oInitialValueSet.m_strAntennaInfo);
 }
 
 void cHDF5FileWriter::antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus)

--- a/HDF5FileWriter.cpp
+++ b/HDF5FileWriter.cpp
@@ -1109,7 +1109,7 @@ void cHDF5FileWriter::observedMaserVlsr_callback(int64_t i64Timestamp_us, double
         sprintf(m_oInitialValueSet.m_chaObservedMaserVlsrStatus, "%s", strStatus.c_str());
     }
     if(getState() == RECORDING)
-        m_pHDF5File->addTemperature(i64Timestamp_us, m_dVObservedMaserVlsr_km_s, strStatus);
+        m_pHDF5File->addObservedMaserVlsr(i64Timestamp_us, m_dVObservedMaserVlsr_km_s, strStatus);
 }
 
 void cHDF5FileWriter::rNoiseDiode5GHzInputSource_callback(int64_t i64Timestamp_us, const string &strInputSource, const string &strStatus)

--- a/HDF5FileWriter.h
+++ b/HDF5FileWriter.h
@@ -268,12 +268,12 @@ class cHDF5FileWriter : public cSpectrometerDataStreamInterpreter::cCallbackInte
         double   m_dVAttenuationADCChan1_dB;
 
         // Antenna configuration
-        std::string         m_strObservationInformation;
-        double              m_dAntennaBeamwidth_deg;
+        std::string m_strAntennaInfo;
+        double      m_dAntennaBeamwidth_deg;
         
         // Observed Maser Name
         int64_t  m_i64TSObservedMaserName_us;
-        char     m_chaVObservedMaserName[164];
+        char     m_chaVObservedMaserName[32];
         char     m_chaObservedMaserNameStatus[7];
         
         // Observed Maser Vlsr
@@ -353,7 +353,7 @@ public:
     void                                                antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus);
 
     void                                                appliedPointingModel_callback(const std::string &strModelName, const std::vector<double> &vdPointingModelParams);
-    void                                                observationInfo_callback(const std::string &strObservationInfo);
+    void                                                antennaInfo_callback(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus);
     void                                                antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);
     void                                                observedMaserName_callback(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus);
     void                                                observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus);

--- a/HDF5FileWriter.h
+++ b/HDF5FileWriter.h
@@ -250,6 +250,8 @@ class cHDF5FileWriter : public cSpectrometerDataStreamInterpreter::cCallbackInte
         // Antenna configuration
         std::string         m_strObservationInformation;
         double              m_dAntennaBeamwidth_deg;
+        std::string         m_strObservedMaserName;
+        double              m_dObservedMaserVlsr_km_s;
 
     } cInitialValueSet;
 
@@ -319,6 +321,9 @@ public:
     void                                                appliedPointingModel_callback(const std::string &strModelName, const std::vector<double> &vdPointingModelParams);
     void                                                observationInfo_callback(const std::string &strObservationInfo);
     void                                                antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);
+    void                                                observedMaserName_callback(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus);
+    void                                                observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus);
+
 
     //Noise diode values
     void                                                rNoiseDiode5GHzInputSource_callback(int64_t i64Timestamp_us, const std::string &strNoiseDiodeInputSource, const std::string &strStatus);

--- a/HDF5FileWriter.h
+++ b/HDF5FileWriter.h
@@ -109,6 +109,26 @@ class cHDF5FileWriter : public cSpectrometerDataStreamInterpreter::cCallbackInte
 
         double  m_aPointingModel[30];
 
+        // Sky-space requested RA offset - cTimestampedDouble
+        int64_t m_i64TSSkyRequestedRaOffset_us;
+        double  m_dVSkyRequestedRaOffset_deg;
+        char    m_chaSkyRequestedRaOffsetStatus[7];
+
+        // Sky-space requested Dec offset - cTimestampedDouble
+        int64_t m_i64TSSkyRequestedDecOffset_us;
+        double  m_dVSkyRequestedDecOffset_deg;
+        char    m_chaSkyRequestedDecOffsetStatus[7];
+
+        // Sky-space requested Azim offset - cTimestampedDouble
+        int64_t m_i64TSSkyRequestedAzOffset_us;
+        double  m_dVSkyRequestedAzOffset_deg;
+        char    m_chaSkyRequestedAzOffsetStatus[7];
+
+        // Sky-space requested Elev offset - cTimestampedDouble
+        int64_t m_i64TSSkyRequestedElOffset_us;
+        double  m_dVSkyRequestedElOffset_deg;
+        char    m_chaSkyRequestedElOffsetStatus[7];
+
         // Antenna status
         int64_t m_i64TSAntennaStatus_us;
         char    m_chaVAntennaStatus[16];
@@ -323,6 +343,12 @@ public:
     void                                                skyActualEl_callback(int64_t i64Timestamp_us, double dElevation_deg, const std::string &strStatus);
 
     void                                                pointingModel_callback(uint8_t ui8ParameterNumber, double dParameterValue);
+
+    //Antenna offsets
+    void                                                skyRequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus);
+    void                                                skyRequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus);
+    void                                                skyRequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus);
+    void                                                skyRequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus);
 
     void                                                antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus);
 

--- a/HDF5FileWriter.h
+++ b/HDF5FileWriter.h
@@ -109,25 +109,25 @@ class cHDF5FileWriter : public cSpectrometerDataStreamInterpreter::cCallbackInte
 
         double  m_aPointingModel[30];
 
-        // Sky-space requested RA offset - cTimestampedDouble
-        int64_t m_i64TSSkyRequestedRaOffset_us;
-        double  m_dVSkyRequestedRaOffset_deg;
-        char    m_chaSkyRequestedRaOffsetStatus[7];
+        // Requested RA offset - cTimestampedDouble
+        int64_t m_i64TSRequestedRaOffset_us;
+        double  m_dVRequestedRaOffset_deg;
+        char    m_chaRequestedRaOffsetStatus[7];
 
-        // Sky-space requested Dec offset - cTimestampedDouble
-        int64_t m_i64TSSkyRequestedDecOffset_us;
-        double  m_dVSkyRequestedDecOffset_deg;
-        char    m_chaSkyRequestedDecOffsetStatus[7];
+        // Requested Dec offset - cTimestampedDouble
+        int64_t m_i64TSRequestedDecOffset_us;
+        double  m_dVRequestedDecOffset_deg;
+        char    m_chaRequestedDecOffsetStatus[7];
 
-        // Sky-space requested Azim offset - cTimestampedDouble
-        int64_t m_i64TSSkyRequestedAzOffset_us;
-        double  m_dVSkyRequestedAzOffset_deg;
-        char    m_chaSkyRequestedAzOffsetStatus[7];
+        // Requested Azim offset - cTimestampedDouble
+        int64_t m_i64TSRequestedAzOffset_us;
+        double  m_dVRequestedAzOffset_deg;
+        char    m_chaRequestedAzOffsetStatus[7];
 
-        // Sky-space requested Elev offset - cTimestampedDouble
-        int64_t m_i64TSSkyRequestedElOffset_us;
-        double  m_dVSkyRequestedElOffset_deg;
-        char    m_chaSkyRequestedElOffsetStatus[7];
+        // Requested Elev offset - cTimestampedDouble
+        int64_t m_i64TSRequestedElOffset_us;
+        double  m_dVRequestedElOffset_deg;
+        char    m_chaRequestedElOffsetStatus[7];
 
         // Antenna status
         int64_t m_i64TSAntennaStatus_us;
@@ -345,10 +345,10 @@ public:
     void                                                pointingModel_callback(uint8_t ui8ParameterNumber, double dParameterValue);
 
     //Antenna offsets
-    void                                                skyRequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus);
-    void                                                skyRequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus);
-    void                                                skyRequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus);
-    void                                                skyRequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus);
+    void                                                RequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus);
+    void                                                RequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus);
+    void                                                RequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus);
+    void                                                RequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus);
 
     void                                                antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus);
 

--- a/HDF5FileWriter.h
+++ b/HDF5FileWriter.h
@@ -271,15 +271,10 @@ class cHDF5FileWriter : public cSpectrometerDataStreamInterpreter::cCallbackInte
         std::string m_strAntennaInfo;
         double      m_dAntennaBeamwidth_deg;
         
-        // Observed Maser Name
-        int64_t  m_i64TSObservedMaserName_us;
-        char     m_chaVObservedMaserName[32];
-        char     m_chaObservedMaserNameStatus[7];
-        
-        // Observed Maser Vlsr
-        int64_t  m_i64TSObservedMaserVlsr_us;
-        double   m_dVObservedMaserVlsr_km_s;
-        char     m_chaObservedMaserVlsrStatus[7];
+        // Observed Maser
+        int64_t     m_i64TSObservedMaser_us;
+        std::string m_strObservedMaser;
+        char        m_chaObservedMaserStatus[7];
 
     } cInitialValueSet;
 
@@ -355,9 +350,7 @@ public:
     void                                                appliedPointingModel_callback(const std::string &strModelName, const std::vector<double> &vdPointingModelParams);
     void                                                antennaInfo_callback(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus);
     void                                                antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);
-    void                                                observedMaserName_callback(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus);
-    void                                                observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus);
-
+    void                                                observedMaser_callback(int64_t i64Timestamp_us, const std::string &strObservedMaser, const std::string &strStatus);
 
     //Noise diode values
     void                                                rNoiseDiode5GHzInputSource_callback(int64_t i64Timestamp_us, const std::string &strNoiseDiodeInputSource, const std::string &strStatus);

--- a/HDF5FileWriter.h
+++ b/HDF5FileWriter.h
@@ -250,8 +250,16 @@ class cHDF5FileWriter : public cSpectrometerDataStreamInterpreter::cCallbackInte
         // Antenna configuration
         std::string         m_strObservationInformation;
         double              m_dAntennaBeamwidth_deg;
-        std::string         m_strObservedMaserName;
-        double              m_dObservedMaserVlsr_km_s;
+        
+        // Observed Maser Name
+        int64_t  m_i64TSObservedMaserName_us;
+        char     m_chaVObservedMaserName[164];
+        char     m_chaObservedMaserNameStatus[7];
+        
+        // Observed Maser Vlsr
+        int64_t  m_i64TSObservedMaserVlsr_us;
+        double   m_dVObservedMaserVlsr_km_s;
+        char     m_chaObservedMaserVlsrStatus[7];
 
     } cInitialValueSet;
 

--- a/HDF5FileWriter.h
+++ b/HDF5FileWriter.h
@@ -276,6 +276,11 @@ class cHDF5FileWriter : public cSpectrometerDataStreamInterpreter::cCallbackInte
         std::string m_strObservedMaser;
         char        m_chaObservedMaserStatus[7];
 
+        // Observation details
+        int64_t     m_i64TSObservationDetails_us;
+        std::string m_strObservationDetails;
+        char        m_chaObservationDetailsStatus[7];
+
     } cInitialValueSet;
 
 public:
@@ -351,7 +356,7 @@ public:
     void                                                antennaInfo_callback(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus);
     void                                                antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);
     void                                                observedMaser_callback(int64_t i64Timestamp_us, const std::string &strObservedMaser, const std::string &strStatus);
-
+    void                                                observationDetails_callback(int64_t i64Timestamp_us, const std::string &strObservationDetails, const std::string &strStatus);
     //Noise diode values
     void                                                rNoiseDiode5GHzInputSource_callback(int64_t i64Timestamp_us, const std::string &strNoiseDiodeInputSource, const std::string &strStatus);
     void                                                rNoiseDiode5GHzLevel_callback(int64_t i64Timestamp_us, const int32_t i32NoiseDiodeLevel_dB, const std::string &strStatus);

--- a/KATCPServer.cpp
+++ b/KATCPServer.cpp
@@ -1327,6 +1327,10 @@ void cKATCPServer::cKATCPClientCallbackHandler::skyDesiredEl_callback(int64_t i6
 void cKATCPServer::cKATCPClientCallbackHandler::skyActualAz_callback(int64_t i64Timestamp_us, double dAzimuth_deg, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::skyActualEl_callback(int64_t i64Timestamp_us, double dElevation_deg, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::pointingModel_callback(uint8_t i8ParameterNumber, double dParameterValue) {}
+void cKATCPServer::cKATCPClientCallbackHandler::skyRequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus) {};
+void cKATCPServer::cKATCPClientCallbackHandler::skyRequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus) {};
+void cKATCPServer::cKATCPClientCallbackHandler::skyRequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus) {};
+void cKATCPServer::cKATCPClientCallbackHandler::skyRequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus) {};
 void cKATCPServer::cKATCPClientCallbackHandler::antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::observationInfo_callback(const std::string &strObservationInfo) {}
 void cKATCPServer::cKATCPClientCallbackHandler::antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus) {}

--- a/KATCPServer.cpp
+++ b/KATCPServer.cpp
@@ -1330,6 +1330,8 @@ void cKATCPServer::cKATCPClientCallbackHandler::pointingModel_callback(uint8_t i
 void cKATCPServer::cKATCPClientCallbackHandler::antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::observationInfo_callback(const std::string &strObservationInfo) {}
 void cKATCPServer::cKATCPClientCallbackHandler::antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus) {}
+void cKATCPServer::cKATCPClientCallbackHandler::observedMaserName_callback(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus) {}
+void cKATCPServer::cKATCPClientCallbackHandler::observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::sourceSelection_callback(int64_t i64Timestamp_us, const std::string &strSourceName, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::onSource_callback(int64_t i64Timestamp_us, const std::string &strValue, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::bandSelectLcp_callback(int64_t i64Timestamp_us, bool bBandSelectLCP, const std::string &strStatus) {}

--- a/KATCPServer.cpp
+++ b/KATCPServer.cpp
@@ -1332,7 +1332,7 @@ void cKATCPServer::cKATCPClientCallbackHandler::RequestedDecOffset_callback(int6
 void cKATCPServer::cKATCPClientCallbackHandler::RequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus) {};
 void cKATCPServer::cKATCPClientCallbackHandler::RequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus) {};
 void cKATCPServer::cKATCPClientCallbackHandler::antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus) {}
-void cKATCPServer::cKATCPClientCallbackHandler::observationInfo_callback(const std::string &strObservationInfo) {}
+void cKATCPServer::cKATCPClientCallbackHandler::antennaInfo_callback(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::observedMaserName_callback(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus) {}

--- a/KATCPServer.cpp
+++ b/KATCPServer.cpp
@@ -1327,10 +1327,10 @@ void cKATCPServer::cKATCPClientCallbackHandler::skyDesiredEl_callback(int64_t i6
 void cKATCPServer::cKATCPClientCallbackHandler::skyActualAz_callback(int64_t i64Timestamp_us, double dAzimuth_deg, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::skyActualEl_callback(int64_t i64Timestamp_us, double dElevation_deg, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::pointingModel_callback(uint8_t i8ParameterNumber, double dParameterValue) {}
-void cKATCPServer::cKATCPClientCallbackHandler::skyRequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus) {};
-void cKATCPServer::cKATCPClientCallbackHandler::skyRequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus) {};
-void cKATCPServer::cKATCPClientCallbackHandler::skyRequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus) {};
-void cKATCPServer::cKATCPClientCallbackHandler::skyRequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus) {};
+void cKATCPServer::cKATCPClientCallbackHandler::RequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus) {};
+void cKATCPServer::cKATCPClientCallbackHandler::RequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus) {};
+void cKATCPServer::cKATCPClientCallbackHandler::RequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus) {};
+void cKATCPServer::cKATCPClientCallbackHandler::RequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus) {};
 void cKATCPServer::cKATCPClientCallbackHandler::antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::observationInfo_callback(const std::string &strObservationInfo) {}
 void cKATCPServer::cKATCPClientCallbackHandler::antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus) {}

--- a/KATCPServer.cpp
+++ b/KATCPServer.cpp
@@ -1335,6 +1335,7 @@ void cKATCPServer::cKATCPClientCallbackHandler::antennaStatus_callback(int64_t i
 void cKATCPServer::cKATCPClientCallbackHandler::antennaInfo_callback(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::observedMaser_callback(int64_t i64Timestamp_us, const std::string &strObservedMaser, const std::string &strStatus) {}
+void cKATCPServer::cKATCPClientCallbackHandler::observationDetails_callback(int64_t i64Timestamp_us, const std::string &strObservationDetails, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::sourceSelection_callback(int64_t i64Timestamp_us, const std::string &strSourceName, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::onSource_callback(int64_t i64Timestamp_us, const std::string &strValue, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::bandSelectLcp_callback(int64_t i64Timestamp_us, bool bBandSelectLCP, const std::string &strStatus) {}

--- a/KATCPServer.cpp
+++ b/KATCPServer.cpp
@@ -1334,8 +1334,7 @@ void cKATCPServer::cKATCPClientCallbackHandler::RequestedElOffset_callback(int64
 void cKATCPServer::cKATCPClientCallbackHandler::antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::antennaInfo_callback(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus) {}
-void cKATCPServer::cKATCPClientCallbackHandler::observedMaserName_callback(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus) {}
-void cKATCPServer::cKATCPClientCallbackHandler::observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus) {}
+void cKATCPServer::cKATCPClientCallbackHandler::observedMaser_callback(int64_t i64Timestamp_us, const std::string &strObservedMaser, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::sourceSelection_callback(int64_t i64Timestamp_us, const std::string &strSourceName, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::onSource_callback(int64_t i64Timestamp_us, const std::string &strValue, const std::string &strStatus) {}
 void cKATCPServer::cKATCPClientCallbackHandler::bandSelectLcp_callback(int64_t i64Timestamp_us, bool bBandSelectLCP, const std::string &strStatus) {}

--- a/KATCPServer.h
+++ b/KATCPServer.h
@@ -142,6 +142,11 @@ public:
         void                                    observationInfo_callback(const std::string &strObservationInfo);
         void                                    antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);
 
+        //Observed Maser values
+        void                                    observedMaserName_callback(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus);
+        void                                    observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus);
+
+
         //Global experiment values
         void                                    sourceSelection_callback(int64_t i64Timestamp_us, const std::string &strSourceName, const std::string &strStatus);
         

--- a/KATCPServer.h
+++ b/KATCPServer.h
@@ -138,6 +138,13 @@ public:
 
         void                                    pointingModel_callback(uint8_t i8ParameterNumber, double dParameterValue);
 
+        //Antenna offsets
+        void                                    skyRequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus);
+        void                                    skyRequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus);
+        void                                    skyRequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus);
+        void                                    skyRequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus);
+
+
         void                                    antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus);
         void                                    observationInfo_callback(const std::string &strObservationInfo);
         void                                    antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);

--- a/KATCPServer.h
+++ b/KATCPServer.h
@@ -139,10 +139,10 @@ public:
         void                                    pointingModel_callback(uint8_t i8ParameterNumber, double dParameterValue);
 
         //Antenna offsets
-        void                                    skyRequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus);
-        void                                    skyRequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus);
-        void                                    skyRequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus);
-        void                                    skyRequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus);
+        void                                    RequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus);
+        void                                    RequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus);
+        void                                    RequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus);
+        void                                    RequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus);
 
 
         void                                    antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus);

--- a/KATCPServer.h
+++ b/KATCPServer.h
@@ -149,10 +149,8 @@ public:
         void                                    antennaInfo_callback(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus);
         void                                    antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);
 
-        //Observed Maser values
-        void                                    observedMaserName_callback(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus);
-        void                                    observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus);
-
+        //Observed Maser
+        void                                    observedMaser_callback(int64_t i64Timestamp_us, const std::string &strObservedMaser, const std::string &strStatus);
 
         //Global experiment values
         void                                    sourceSelection_callback(int64_t i64Timestamp_us, const std::string &strSourceName, const std::string &strStatus);

--- a/KATCPServer.h
+++ b/KATCPServer.h
@@ -146,7 +146,7 @@ public:
 
 
         void                                    antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus);
-        void                                    observationInfo_callback(const std::string &strObservationInfo);
+        void                                    antennaInfo_callback(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus);
         void                                    antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);
 
         //Observed Maser values

--- a/KATCPServer.h
+++ b/KATCPServer.h
@@ -152,6 +152,9 @@ public:
         //Observed Maser
         void                                    observedMaser_callback(int64_t i64Timestamp_us, const std::string &strObservedMaser, const std::string &strStatus);
 
+        //Observation details
+        void                                    observationDetails_callback(int64_t i64Timestamp_us, const std::string &strObservationDetails, const std::string &strStatus);
+
         //Global experiment values
         void                                    sourceSelection_callback(int64_t i64Timestamp_us, const std::string &strSourceName, const std::string &strStatus);
         

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If making changes to the SpectrometerDataStream repo (submodule located in AVNDa
 When committing and pushing, any changes to the SpectrometerDataStream repo must be committed first, so that the link to the submodule is preserved. Push the submodule, and then the main repo.
 
 ## Build Image
-`docker build -t roach2 .`
+`docker build --no-cache -t roach2 .`
 
 ## Run Container
 ```
@@ -33,5 +33,5 @@ roach2 /workspace/RoachAcquisitionServer/bin/RoachAcquisitionServer \
 Add the servers (Reber) ssh key to your GitHub account. Git pull as normal.
 After pulling, submodules may need to be sync'd: `git submodule update --init --recursive`
 If desired, save a copy of the current image: `docker tag roach2:latest roach2:20260501`
-Build the image: `docker build -t roach2 .`
+Build the image: `docker --no-cache build -t roach2 .`
 Run by executing `./startWBS.sh` in the home directory

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ When committing and pushing, any changes to the SpectrometerDataStream repo must
 `git remote set-url origin git@github.com:ska-sa/AVNSpectrometerDataStream.git`
 
 ## Build Image
+### Local Development Machine
+First build the base image, once off, followed by the development image whenever you want to test the code builds.
+`docker build -f Dockerfile-dev-base --no-cache -t roach2-base .`
+`docker build -f Dockerfile-dev --no-cache -t roach2-dev .`
+
+### Production Server
 `docker build --no-cache -t roach2 .`
 
 ## Run Container

--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ After pulling, submodules may need to be sync'd: `git submodule update --init --
 If desired, save a copy of the current image: `docker tag roach2:latest roach2:20260501`
 Build the image: `docker --no-cache build -t roach2 .`
 Run by executing `./startWBS.sh` in the home directory
+
+## Testing a branch on site
+Modify the Dockerfile in `/home/avnuser/AVNSoftware/RoachAcquisitionServer` add the followiong lines after the `WORKDIR /workspace/RoachAcquisitionServer`
+```
+RUN git checkout <branch-name>
+RUN git submodule update --init --recursive
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Roach Acquisition Server
+
+## Clone Repo
+`git clone --recurse-submodules git@github.com:ska-sa/RoachAcquisitionServer.git`
+
+## Checkout
+If making changes to the SpectrometerDataStream repo (submodule located in AVNDataTypes), you must checkout the `scam_integration` branch.
+
+## Commit and Push
+When committing and pushing, any changes to the SpectrometerDataStream repo must be committed first, so that the link to the submodule is preserved. Push the submodule, and then the main repo.
+
+## Build Image
+`docker build -t roach2 .`
+
+## Run Container
+```
+docker run -dt --name roach2_environment --network host --rm \
+-v $HOME/Data/RoachAcquisition:/data \
+-v $HOME/AVNSoftware/RoachLaunchers:/workspace/RoachLaunchers \
+-v $HOME/AVNSoftware/RoachAcquisitionServer/NoiseDiode:/etc/NoiseDiode \
+-v /etc/ObservatoryInfo.ini:/etc/ObservatoryInfo.ini \
+roach2 /workspace/RoachAcquisitionServer/bin/RoachAcquisitionServer \
+--local-interface=10.0.3.1 \
+--roach-address=10.0.3.2 \
+--roach-ppc-address=10.0.2.43 \
+--roach-gateware-dir=/workspace/RoachLaunchers \
+--station-controller-address=172.16.16.134 \
+--station-controller-port=40001 \
+--recording-dir=/data
+```
+
+## Site deployment
+Add the servers (Reber) ssh key to your GitHub account. Git pull as normal.
+After pulling, submodules may need to be sync'd: `git submodule update --init --recursive`
+If desired, save a copy of the current image: `docker tag roach2:latest roach2:20260501`
+Build the image: `docker build -t roach2 .`
+Run by executing `./startWBS.sh` in the home directory

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 If making changes to the SpectrometerDataStream repo (submodule located in AVNDataTypes), you must checkout the `scam_integration` branch.
 
 ## Commit and Push
-When committing and pushing, any changes to the SpectrometerDataStream repo must be committed first, so that the link to the submodule is preserved. Push the submodule, and then the main repo.
+When committing and pushing, any changes to the SpectrometerDataStream repo must be committed first, so that the link to the submodule is preserved. Push the submodule, and then the main repo. You may need to change from https to ssh as follows:
+`git remote set-url origin git@github.com:ska-sa/AVNSpectrometerDataStream.git`
 
 ## Build Image
 `docker build --no-cache -t roach2 .`

--- a/StationControllerKATCPClient.cpp
+++ b/StationControllerKATCPClient.cpp
@@ -94,7 +94,7 @@ cStationControllerKATCPClient::cStationControllerKATCPClient() :
 
     // Observation metadata such as targets, etc.
     m_vstrSensorSampling.push_back("SCS.HPBW event");
-    m_vstrSensorSampling.push_back("SCS.ObservationInformation event");
+    m_vstrSensorSampling.push_back("SCS.AntennaInfo event");
     m_vstrSensorSampling.push_back("SCS.observed-maser-name event");
     m_vstrSensorSampling.push_back("SCS.observed-maser-vlsr event");
 }
@@ -598,9 +598,9 @@ void cStationControllerKATCPClient::processKATCPMessage(const vector<string> &vs
         return;
     }
 
-    if( !vstrTokens[3].compare("SCS.ObservationInformation") )
+    if( !vstrTokens[3].compare("SCS.AntennaInfo") )
     {
-        sendObservationInfo( strtod(vstrTokens[1].c_str(), NULL)*1e6, vstrTokens[5].c_str(), vstrTokens[4].c_str() );
+        sendAntennaInfo( strtod(vstrTokens[1].c_str(), NULL)*1e6, vstrTokens[5].c_str(), vstrTokens[4].c_str() );
         return;
     }
 
@@ -1441,7 +1441,7 @@ void cStationControllerKATCPClient::sendAntennaBeamwidth(int64_t i64Timestamp_us
     }
 }
 
-void cStationControllerKATCPClient::sendObservationInfo(int64_t i64Timestamp_us, const string &strObservationInformation, const std::string &strStatus)
+void cStationControllerKATCPClient::sendAntennaInfo(int64_t i64Timestamp_us, const string &strAntennaInfo, const std::string &strStatus)
 {
     boost::shared_lock<boost::shared_mutex> oLock(m_oCallbackHandlersMutex);
 
@@ -1451,13 +1451,13 @@ void cStationControllerKATCPClient::sendObservationInfo(int64_t i64Timestamp_us,
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
     {
         cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
-        pHandler->observationInfo_callback(strObservationInformation);
+        pHandler->antennaInfo_callback(i64Timestamp_us, strAntennaInfo, strStatus);
     }
 
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
     {
         boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
-        pHandler->observationInfo_callback(strObservationInformation);
+        pHandler->antennaInfo_callback(i64Timestamp_us, strAntennaInfo, strStatus);
     }
 }
 

--- a/StationControllerKATCPClient.cpp
+++ b/StationControllerKATCPClient.cpp
@@ -95,8 +95,7 @@ cStationControllerKATCPClient::cStationControllerKATCPClient() :
     // Observation metadata such as targets, etc.
     m_vstrSensorSampling.push_back("SCS.HPBW event");
     m_vstrSensorSampling.push_back("SCS.AntennaInfo event");
-    m_vstrSensorSampling.push_back("SCS.observed-maser-name event");
-    m_vstrSensorSampling.push_back("SCS.observed-maser-vlsr event");
+    m_vstrSensorSampling.push_back("SCS.observed-maser event");
 }
 
 cStationControllerKATCPClient::~cStationControllerKATCPClient()
@@ -604,15 +603,9 @@ void cStationControllerKATCPClient::processKATCPMessage(const vector<string> &vs
         return;
     }
 
-    if( !vstrTokens[3].compare("SCS.observed-maser-name") )
+    if( !vstrTokens[3].compare("SCS.observed-maser") )
     {
-        sendObservedMaserName( strtod(vstrTokens[1].c_str(), NULL)*1e6, vstrTokens[5].c_str(), vstrTokens[4].c_str() );
-        return;
-    }
-
-    if( !vstrTokens[3].compare("SCS.observed-maser-vlsr") )
-    {
-        sendObservedMaserVlsr( strtod(vstrTokens[1].c_str(), NULL)*1e6, strtod(vstrTokens[5].c_str(), NULL), vstrTokens[4].c_str() );
+        sendObservedMaser( strtod(vstrTokens[1].c_str(), NULL)*1e6, vstrTokens[5].c_str(), vstrTokens[4].c_str() );
         return;
     }
 // PJP
@@ -1461,7 +1454,7 @@ void cStationControllerKATCPClient::sendAntennaInfo(int64_t i64Timestamp_us, con
     }
 }
 
-void cStationControllerKATCPClient::sendObservedMaserName(int64_t i64Timestamp_us, const string &strObservedMaserName, const std::string &strStatus)
+void cStationControllerKATCPClient::sendObservedMaser(int64_t i64Timestamp_us, const string &strObservedMaser, const std::string &strStatus)
 {
     boost::shared_lock<boost::shared_mutex> oLock(m_oCallbackHandlersMutex);
 
@@ -1471,33 +1464,13 @@ void cStationControllerKATCPClient::sendObservedMaserName(int64_t i64Timestamp_u
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
     {
         cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
-        pHandler->observedMaserName_callback(i64Timestamp_us, strObservedMaserName, strStatus);
+        pHandler->observedMaser_callback(i64Timestamp_us, strObservedMaser, strStatus);
     }
 
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
     {
         boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
-        pHandler->observedMaserName_callback(i64Timestamp_us, strObservedMaserName, strStatus);
-    }
-}
-
-void cStationControllerKATCPClient::sendObservedMaserVlsr(int64_t i64Timestamp_us, double dObservedMaserVlsr, const std::string &strStatus)
-{
-    boost::shared_lock<boost::shared_mutex> oLock(m_oCallbackHandlersMutex);
-
-    //Note the vector contains the base type callback handler pointer so cast to the derived version is this class
-    //to call function added in the derived version of the callback handler interface class
-
-    for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
-    {
-        cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
-        pHandler->observedMaserVlsr_callback(i64Timestamp_us, dObservedMaserVlsr, strStatus);
-    }
-
-    for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
-    {
-        boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
-        pHandler->observedMaserVlsr_callback(i64Timestamp_us, dObservedMaserVlsr, strStatus);
+        pHandler->observedMaser_callback(i64Timestamp_us, strObservedMaser, strStatus);
     }
 }
 

--- a/StationControllerKATCPClient.cpp
+++ b/StationControllerKATCPClient.cpp
@@ -89,6 +89,8 @@ cStationControllerKATCPClient::cStationControllerKATCPClient() :
     // Observation metadata such as targets, etc.
     m_vstrSensorSampling.push_back("SCS.HPBW event");
     m_vstrSensorSampling.push_back("SCS.ObservationInformation event");
+    m_vstrSensorSampling.push_back("SCS.observed-maser-name event");
+    m_vstrSensorSampling.push_back("SCS.observed-maser-vlsr event");
 }
 
 cStationControllerKATCPClient::~cStationControllerKATCPClient()
@@ -569,6 +571,18 @@ void cStationControllerKATCPClient::processKATCPMessage(const vector<string> &vs
     if( !vstrTokens[3].compare("SCS.ObservationInformation") )
     {
         sendObservationInfo( strtod(vstrTokens[1].c_str(), NULL)*1e6, vstrTokens[5].c_str(), vstrTokens[4].c_str() );
+        return;
+    }
+
+    if( !vstrTokens[3].compare("SCS.observed-maser-name") )
+    {
+        sendObservedMaserName( strtod(vstrTokens[1].c_str(), NULL)*1e6, vstrTokens[5].c_str(), vstrTokens[4].c_str() );
+        return;
+    }
+
+    if( !vstrTokens[3].compare("SCS.observed-maser-vlsr") )
+    {
+        sendObservedMaserVlsr( strtod(vstrTokens[1].c_str(), NULL)*1e6, strtod(vstrTokens[5].c_str(), NULL), vstrTokens[4].c_str() );
         return;
     }
 // PJP
@@ -1340,6 +1354,45 @@ void cStationControllerKATCPClient::sendObservationInfo(int64_t i64Timestamp_us,
     }
 }
 
+void cStationControllerKATCPClient::sendObservedMaserName(int64_t i64Timestamp_us, const string &strObservedMaserName, const std::string &strStatus)
+{
+    boost::shared_lock<boost::shared_mutex> oLock(m_oCallbackHandlersMutex);
+
+    //Note the vector contains the base type callback handler pointer so cast to the derived version is this class
+    //to call function added in the derived version of the callback handler interface class
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
+    {
+        cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
+        pHandler->observedMaserName_callback(strObservedMaserName);
+    }
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
+    {
+        boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
+        pHandler->observedMaserName_callback(strObservedMaserName);
+    }
+}
+
+void cStationControllerKATCPClient::sendObservedMaserVlsr(int64_t i64Timestamp_us, double dObservedMaserVlsr, const std::string &strStatus)
+{
+    boost::shared_lock<boost::shared_mutex> oLock(m_oCallbackHandlersMutex);
+
+    //Note the vector contains the base type callback handler pointer so cast to the derived version is this class
+    //to call function added in the derived version of the callback handler interface class
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
+    {
+        cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
+        pHandler->observedMaserVlsr_callback(i64Timestamp_us, dObservedMaserVlsr, strStatus);
+    }
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
+    {
+        boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
+        pHandler->observedMaserVlsr_callback(i64Timestamp_us, dObservedMaserVlsr, strStatus);
+    }
+}
 
 // Don't remove - this should still be implemented in the station controller.
 // Eventually.

--- a/StationControllerKATCPClient.cpp
+++ b/StationControllerKATCPClient.cpp
@@ -62,6 +62,12 @@ cStationControllerKATCPClient::cStationControllerKATCPClient() :
     m_vstrSensorSampling.push_back("SCS.pmodel29 event");
     m_vstrSensorSampling.push_back("SCS.pmodel30 event");
 
+    // Antenna offsets
+    m_vstrSensorSampling.push_back("SCS.requested-raoff event");
+    m_vstrSensorSampling.push_back("SCS.requested-decoff event");
+    m_vstrSensorSampling.push_back("SCS.requested-azimoff event");
+    m_vstrSensorSampling.push_back("SCS.requested-elevoff event");
+
     // Antenna status
     m_vstrSensorSampling.push_back("SCS.AntennaActivity event");
     m_vstrSensorSampling.push_back("SCS.Target event");
@@ -381,6 +387,30 @@ void cStationControllerKATCPClient::processKATCPMessage(const vector<string> &vs
         sendPointingModelParameter( strtol(vstrTokens[3].substr(10,vstrTokens[3].size() - 10).c_str(), NULL, 10), strtod(vstrTokens[5].c_str(), NULL));
     }
 
+    // Antenna offsets
+    if( !vstrTokens[3].compare("SCS.requested-raoff") )
+    {
+        sendRequestedRaOffset( strtod(vstrTokens[1].c_str(), NULL)*1e6, strtod(vstrTokens[5].c_str(), NULL), vstrTokens[4].c_str() );
+        return;
+    }
+
+    if( !vstrTokens[3].compare("SCS.requested-decoff") )
+    {
+        sendRequestedDecOffset( strtod(vstrTokens[1].c_str(), NULL)*1e6, strtod(vstrTokens[5].c_str(), NULL), vstrTokens[4].c_str() );
+        return;
+    }
+
+    if( !vstrTokens[3].compare("SCS.requested-azimoff") )
+    {
+        sendRequestedAzimOffset( strtod(vstrTokens[1].c_str(), NULL)*1e6, strtod(vstrTokens[5].c_str(), NULL), vstrTokens[4].c_str() );
+        return;
+    }
+
+    if( !vstrTokens[3].compare("SCS.requested-elevoff") )
+    {
+        sendRequestedElevOffset( strtod(vstrTokens[1].c_str(), NULL)*1e6, strtod(vstrTokens[5].c_str(), NULL), vstrTokens[4].c_str() );
+        return;
+    }
 
     // Antenna status
     if(!vstrTokens[3].compare("SCS.AntennaActivity"))
@@ -879,8 +909,6 @@ void cStationControllerKATCPClient::sendSkyActualAntennaEl(int64_t i64Timestamp_
     }
 }
 
-
-
 void cStationControllerKATCPClient::sendPointingModelParameter(uint8_t ui8ParameterNumber, double dParameterValue)
 {
     boost::shared_lock<boost::shared_mutex> oLock(m_oCallbackHandlersMutex);
@@ -898,6 +926,86 @@ void cStationControllerKATCPClient::sendPointingModelParameter(uint8_t ui8Parame
     {
         boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
         pHandler->pointingModel_callback(ui8ParameterNumber, dParameterValue);
+    }
+}
+
+void cStationControllerKATCPClient::sendRequestedRaOffset(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus)
+{
+    boost::shared_lock<boost::shared_mutex> oLock(m_oCallbackHandlersMutex);
+
+    //Note the vector contains the base type callback handler pointer so cast to the derived version is this class
+    //to call function added in the derived version of the callback handler interface class
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
+    {
+        cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
+        pHandler->skyRequestedRaOffset_callback(i64Timestamp_us, dRightAscensionOffset_deg, strStatus);
+    }
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
+    {
+        boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
+        pHandler->skyRequestedRaOffset_callback(i64Timestamp_us, dRightAscensionOffset_deg, strStatus);
+    }
+}
+
+void cStationControllerKATCPClient::sendRequestedDecOffset(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus)
+{
+    boost::shared_lock<boost::shared_mutex> oLock(m_oCallbackHandlersMutex);
+
+    //Note the vector contains the base type callback handler pointer so cast to the derived version is this class
+    //to call function added in the derived version of the callback handler interface class
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
+    {
+        cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
+        pHandler->skyRequestedDecOffset_callback(i64Timestamp_us, dDeclinationOffset_deg, strStatus);
+    }
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
+    {
+        boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
+        pHandler->skyRequestedDecOffset_callback(i64Timestamp_us, dDeclinationOffset_deg, strStatus);
+    }
+}
+
+void cStationControllerKATCPClient::sendRequestedAzimOffset(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus)
+{
+    boost::shared_lock<boost::shared_mutex> oLock(m_oCallbackHandlersMutex);
+
+    //Note the vector contains the base type callback handler pointer so cast to the derived version is this class
+    //to call function added in the derived version of the callback handler interface class
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
+    {
+        cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
+        pHandler->skyRequestedAzOffset_callback(i64Timestamp_us, dAzimuthOffset_deg, strStatus);
+    }
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
+    {
+        boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
+        pHandler->skyRequestedAzOffset_callback(i64Timestamp_us, dAzimuthOffset_deg, strStatus);
+    }
+}
+
+void cStationControllerKATCPClient::sendRequestedElevOffset(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus)
+{
+    boost::shared_lock<boost::shared_mutex> oLock(m_oCallbackHandlersMutex);
+
+    //Note the vector contains the base type callback handler pointer so cast to the derived version is this class
+    //to call function added in the derived version of the callback handler interface class
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
+    {
+        cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
+        pHandler->skyRequestedElOffset_callback(i64Timestamp_us, dElevationOffset_deg, strStatus);
+    }
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
+    {
+        boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
+        pHandler->skyRequestedElOffset_callback(i64Timestamp_us, dElevationOffset_deg, strStatus);
     }
 }
 
@@ -920,7 +1028,6 @@ void cStationControllerKATCPClient::sendAntennaStatus(int64_t i64Timestamp_us, s
         pHandler->antennaStatus_callback(i64Timestamp_us, strAntennaStatus, strStatus);
     }
 }
-
 
 void cStationControllerKATCPClient::sendNoiseDiodeState(int64_t i64Timestamp_us, int32_t i32NoiseDiodeState, bool bNoiseDiodeSelect, const string &strStatus)
 {

--- a/StationControllerKATCPClient.cpp
+++ b/StationControllerKATCPClient.cpp
@@ -1364,13 +1364,13 @@ void cStationControllerKATCPClient::sendObservedMaserName(int64_t i64Timestamp_u
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
     {
         cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
-        pHandler->observedMaserName_callback(strObservedMaserName);
+        pHandler->observedMaserName_callback(i64Timestamp_us, strObservedMaserName, strStatus);
     }
 
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
     {
         boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
-        pHandler->observedMaserName_callback(strObservedMaserName);
+        pHandler->observedMaserName_callback(i64Timestamp_us, strObservedMaserName, strStatus);
     }
 }
 

--- a/StationControllerKATCPClient.cpp
+++ b/StationControllerKATCPClient.cpp
@@ -939,13 +939,13 @@ void cStationControllerKATCPClient::sendRequestedRaOffset(int64_t i64Timestamp_u
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
     {
         cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
-        pHandler->skyRequestedRaOffset_callback(i64Timestamp_us, dRightAscensionOffset_deg, strStatus);
+        pHandler->RequestedRaOffset_callback(i64Timestamp_us, dRightAscensionOffset_deg, strStatus);
     }
 
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
     {
         boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
-        pHandler->skyRequestedRaOffset_callback(i64Timestamp_us, dRightAscensionOffset_deg, strStatus);
+        pHandler->RequestedRaOffset_callback(i64Timestamp_us, dRightAscensionOffset_deg, strStatus);
     }
 }
 
@@ -959,13 +959,13 @@ void cStationControllerKATCPClient::sendRequestedDecOffset(int64_t i64Timestamp_
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
     {
         cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
-        pHandler->skyRequestedDecOffset_callback(i64Timestamp_us, dDeclinationOffset_deg, strStatus);
+        pHandler->RequestedDecOffset_callback(i64Timestamp_us, dDeclinationOffset_deg, strStatus);
     }
 
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
     {
         boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
-        pHandler->skyRequestedDecOffset_callback(i64Timestamp_us, dDeclinationOffset_deg, strStatus);
+        pHandler->RequestedDecOffset_callback(i64Timestamp_us, dDeclinationOffset_deg, strStatus);
     }
 }
 
@@ -979,13 +979,13 @@ void cStationControllerKATCPClient::sendRequestedAzimOffset(int64_t i64Timestamp
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
     {
         cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
-        pHandler->skyRequestedAzOffset_callback(i64Timestamp_us, dAzimuthOffset_deg, strStatus);
+        pHandler->RequestedAzOffset_callback(i64Timestamp_us, dAzimuthOffset_deg, strStatus);
     }
 
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
     {
         boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
-        pHandler->skyRequestedAzOffset_callback(i64Timestamp_us, dAzimuthOffset_deg, strStatus);
+        pHandler->RequestedAzOffset_callback(i64Timestamp_us, dAzimuthOffset_deg, strStatus);
     }
 }
 
@@ -999,13 +999,13 @@ void cStationControllerKATCPClient::sendRequestedElevOffset(int64_t i64Timestamp
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
     {
         cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
-        pHandler->skyRequestedElOffset_callback(i64Timestamp_us, dElevationOffset_deg, strStatus);
+        pHandler->RequestedElOffset_callback(i64Timestamp_us, dElevationOffset_deg, strStatus);
     }
 
     for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
     {
         boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
-        pHandler->skyRequestedElOffset_callback(i64Timestamp_us, dElevationOffset_deg, strStatus);
+        pHandler->RequestedElOffset_callback(i64Timestamp_us, dElevationOffset_deg, strStatus);
     }
 }
 

--- a/StationControllerKATCPClient.cpp
+++ b/StationControllerKATCPClient.cpp
@@ -96,6 +96,7 @@ cStationControllerKATCPClient::cStationControllerKATCPClient() :
     m_vstrSensorSampling.push_back("SCS.HPBW event");
     m_vstrSensorSampling.push_back("SCS.AntennaInfo event");
     m_vstrSensorSampling.push_back("SCS.observed-maser event");
+    m_vstrSensorSampling.push_back("SCS.observation-details event");
 }
 
 cStationControllerKATCPClient::~cStationControllerKATCPClient()
@@ -606,6 +607,12 @@ void cStationControllerKATCPClient::processKATCPMessage(const vector<string> &vs
     if( !vstrTokens[3].compare("SCS.observed-maser") )
     {
         sendObservedMaser( strtod(vstrTokens[1].c_str(), NULL)*1e6, vstrTokens[5].c_str(), vstrTokens[4].c_str() );
+        return;
+    }
+
+    if( !vstrTokens[3].compare("SCS.observation-details") )
+    {
+        sendObservationDetails( strtod(vstrTokens[1].c_str(), NULL)*1e6, vstrTokens[5].c_str(), vstrTokens[4].c_str() );
         return;
     }
 // PJP
@@ -1471,6 +1478,26 @@ void cStationControllerKATCPClient::sendObservedMaser(int64_t i64Timestamp_us, c
     {
         boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
         pHandler->observedMaser_callback(i64Timestamp_us, strObservedMaser, strStatus);
+    }
+}
+
+void cStationControllerKATCPClient::sendObservationDetails(int64_t i64Timestamp_us, const string &strObservationDetails, const std::string &strStatus)
+{
+    boost::shared_lock<boost::shared_mutex> oLock(m_oCallbackHandlersMutex);
+
+    //Note the vector contains the base type callback handler pointer so cast to the derived version is this class
+    //to call function added in the derived version of the callback handler interface class
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers.size(); ui++)
+    {
+        cCallbackInterface *pHandler = dynamic_cast<cCallbackInterface*>(m_vpCallbackHandlers[ui]);
+        pHandler->observationDetails_callback(i64Timestamp_us, strObservationDetails, strStatus);
+    }
+
+    for(uint32_t ui = 0; ui < m_vpCallbackHandlers_shared.size(); ui++)
+    {
+        boost::shared_ptr<cCallbackInterface> pHandler = boost::dynamic_pointer_cast<cCallbackInterface>(m_vpCallbackHandlers_shared[ui]);
+        pHandler->observationDetails_callback(i64Timestamp_us, strObservationDetails, strStatus);
     }
 }
 

--- a/StationControllerKATCPClient.h
+++ b/StationControllerKATCPClient.h
@@ -50,6 +50,9 @@ public:
         //Observed Maser
         virtual void                                    observedMaser_callback(int64_t i64Timestamp_us, const std::string &strObservedMaser, const std::string &strStatus) = 0;
 
+        //Observation details
+        virtual void                                    observationDetails_callback(int64_t i64Timestamp_us, const std::string &strObservationDetails, const std::string &strStatus) = 0;
+
         //Global experiment values
         virtual void                                    sourceSelection_callback(int64_t i64Timestamp_us, const std::string &strSourceName, const std::string &strStatus) = 0;
         // Onsource sensor
@@ -134,6 +137,7 @@ private:
     void                                                sendAntennaBeamwidth(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);
     void                                                sendAntennaInfo(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus);
     void                                                sendObservedMaser(int64_t i64Timestamp_us, const std::string &strObservedMaser, const std::string &strStatus);
+    void                                                sendObservationDetails(int64_t i64Timestamp_us, const std::string &strObservationDetails, const std::string &strStatus);
 // PJP
 
     //Noise diode values

--- a/StationControllerKATCPClient.h
+++ b/StationControllerKATCPClient.h
@@ -41,6 +41,10 @@ public:
         virtual void                                    antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus) = 0;
         virtual void                                    antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus) = 0;
 
+        //Observed Maser values
+        virtual void                                    observedMaserName_callback(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus) = 0;
+        virtual void                                    observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus) = 0;
+
         //Global experiment values
         virtual void                                    sourceSelection_callback(int64_t i64Timestamp_us, const std::string &strSourceName, const std::string &strStatus) = 0;
         // Onsource sensor

--- a/StationControllerKATCPClient.h
+++ b/StationControllerKATCPClient.h
@@ -43,7 +43,7 @@ public:
         virtual void                                    RequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus) = 0;
         virtual void                                    RequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus) = 0;
 
-        virtual void                                    observationInfo_callback(const std::string &strstrObservationInfo) = 0;
+        virtual void                                    antennaInfo_callback(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus) = 0;
         virtual void                                    antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus) = 0;
         virtual void                                    antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus) = 0;
 
@@ -133,7 +133,7 @@ private:
     void                                                sendAntennaStatus(int64_t i64Timestamp_us, std::string strAntennaStatus, const std::string &strStatus);
 // PJP    
     void                                                sendAntennaBeamwidth(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);
-    void                                                sendObservationInfo(int64_t i64Timestamp_us, const std::string &strObservationInformation, const std::string &strStatus);
+    void                                                sendAntennaInfo(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus);
     void                                                sendObservedMaserName(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus);
     void                                                sendObservedMaserVlsr(int64_t i64Timestamp_us, double dObservedMaserVlsr, const std::string &strStatus);
 // PJP

--- a/StationControllerKATCPClient.h
+++ b/StationControllerKATCPClient.h
@@ -117,6 +117,8 @@ private:
 // PJP    
     void                                                sendAntennaBeamwidth(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);
     void                                                sendObservationInfo(int64_t i64Timestamp_us, const std::string &strObservationInformation, const std::string &strStatus);
+    void                                                sendObservedMaserName(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus);
+    void                                                sendObservedMaserVlsr(int64_t i64Timestamp_us, double dObservedMaserVlsr, const std::string &strStatus);
 // PJP
 
     //Noise diode values

--- a/StationControllerKATCPClient.h
+++ b/StationControllerKATCPClient.h
@@ -47,9 +47,8 @@ public:
         virtual void                                    antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus) = 0;
         virtual void                                    antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus) = 0;
 
-        //Observed Maser values
-        virtual void                                    observedMaserName_callback(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus) = 0;
-        virtual void                                    observedMaserVlsr_callback(int64_t i64Timestamp_us, double dObservedMaserVlsr_km_s, const std::string &strStatus) = 0;
+        //Observed Maser
+        virtual void                                    observedMaser_callback(int64_t i64Timestamp_us, const std::string &strObservedMaser, const std::string &strStatus) = 0;
 
         //Global experiment values
         virtual void                                    sourceSelection_callback(int64_t i64Timestamp_us, const std::string &strSourceName, const std::string &strStatus) = 0;
@@ -134,8 +133,7 @@ private:
 // PJP    
     void                                                sendAntennaBeamwidth(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus);
     void                                                sendAntennaInfo(int64_t i64Timestamp_us, const std::string &strAntennaInfo, const std::string &strStatus);
-    void                                                sendObservedMaserName(int64_t i64Timestamp_us, const std::string &strObservedMaserName, const std::string &strStatus);
-    void                                                sendObservedMaserVlsr(int64_t i64Timestamp_us, double dObservedMaserVlsr, const std::string &strStatus);
+    void                                                sendObservedMaser(int64_t i64Timestamp_us, const std::string &strObservedMaser, const std::string &strStatus);
 // PJP
 
     //Noise diode values

--- a/StationControllerKATCPClient.h
+++ b/StationControllerKATCPClient.h
@@ -38,10 +38,10 @@ public:
         virtual void                                    pointingModel_callback(uint8_t i8ParameterNumber, double dParameterValue) = 0;
 
         //Antenna offsets
-        virtual void                                    skyRequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus) = 0;
-        virtual void                                    skyRequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus) = 0;
-        virtual void                                    skyRequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus) = 0;
-        virtual void                                    skyRequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus) = 0;
+        virtual void                                    RequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus) = 0;
+        virtual void                                    RequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus) = 0;
+        virtual void                                    RequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus) = 0;
+        virtual void                                    RequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus) = 0;
 
         virtual void                                    observationInfo_callback(const std::string &strstrObservationInfo) = 0;
         virtual void                                    antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus) = 0;

--- a/StationControllerKATCPClient.h
+++ b/StationControllerKATCPClient.h
@@ -37,6 +37,12 @@ public:
 
         virtual void                                    pointingModel_callback(uint8_t i8ParameterNumber, double dParameterValue) = 0;
 
+        //Antenna offsets
+        virtual void                                    skyRequestedRaOffset_callback(int64_t i64Timestamp_us, double dRightAscensionOffset_deg, const std::string &strStatus) = 0;
+        virtual void                                    skyRequestedDecOffset_callback(int64_t i64Timestamp_us, double dDeclinationOffset_deg, const std::string &strStatus) = 0;
+        virtual void                                    skyRequestedAzOffset_callback(int64_t i64Timestamp_us, double dAzimuthOffset_deg, const std::string &strStatus) = 0;
+        virtual void                                    skyRequestedElOffset_callback(int64_t i64Timestamp_us, double dElevationOffset_deg, const std::string &strStatus) = 0;
+
         virtual void                                    observationInfo_callback(const std::string &strstrObservationInfo) = 0;
         virtual void                                    antennaBeamwidth_callback(int64_t i64Timestamp_us, const std::string &strAntennaBeamwidth, const std::string &strStatus) = 0;
         virtual void                                    antennaStatus_callback(int64_t i64Timestamp_us, const std::string &strAntennaStatus, const std::string &strStatus) = 0;
@@ -116,6 +122,13 @@ private:
     void                                                sendSkyActualAntennaEl(int64_t i64Timestamp_us,double dElevation_deg, const std::string &strStatus);
 
     void                                                sendPointingModelParameter(uint8_t ui8ParameterNumber, double dParameterValue);
+
+    //Antenna offsets
+    void                                                sendRequestedRaOffset(int64_t i64Timestamp_us, double dRequestedRaOffset, const std::string &strStatus);
+    void                                                sendRequestedDecOffset(int64_t i64Timestamp_us, double dRequestedDecOffset, const std::string &strStatus);
+    void                                                sendRequestedAzimOffset(int64_t i64Timestamp_us, double dRequestedAzimOffset, const std::string &strStatus);
+    void                                                sendRequestedElevOffset(int64_t i64Timestamp_us, double dRequestedElevOffset, const std::string &strStatus);
+
     // TODO: Figure out what to do about this one.
     void                                                sendAntennaStatus(int64_t i64Timestamp_us, std::string strAntennaStatus, const std::string &strStatus);
 // PJP    

--- a/startWBS.sh
+++ b/startWBS.sh
@@ -1,0 +1,22 @@
+cat startWBS.sh
+#!/bin/sh
+echo "Start the Wideband Specrometer"
+echo "Watch the error messages - specifically if 10 GbE link is up"
+cd /home/avnuser/AVNSoftware/RoachLaunchers
+python LaunchWBSpectrometer.py
+sleep 5s
+echo "Start the acquisition server in new window"
+echo "Watch the output for error messages"
+docker run -dt --name roach2_environment --network host --rm \
+-v $HOME/Data/RoachAcquisition:/data \
+-v $HOME/AVNSoftware/RoachLaunchers:/workspace/RoachLaunchers \
+-v $HOME/AVNSoftware/RoachAcquisitionServer/NoiseDiode:/etc/NoiseDiode \
+-v /etc/ObservatoryInfo.ini:/etc/ObservatoryInfo.ini \
+roach2 /workspace/RoachAcquisitionServer/bin/RoachAcquisitionServer \
+--local-interface=10.0.3.1 \
+--roach-address=10.0.3.2 \
+--roach-ppc-address=10.0.2.43 \
+--roach-gateware-dir=/workspace/RoachLaunchers \
+--station-controller-address=172.16.16.134 \
+--station-controller-port=40001 \
+--recording-dir=/data


### PR DESCRIPTION
This adds sensor sampling to the newly added observer-maser sensors, and the radec and azel offset sensors. It also adds these sensors to the HDF5file.

<img width="810" height="1267" alt="image" src="https://github.com/user-attachments/assets/8a733fa7-413d-467d-be0d-3ebd51249563" />

Also updated the NoiseDiode field names to have lower case "ghz" to be standard.

<img width="751" height="450" alt="image" src="https://github.com/user-attachments/assets/d83c1b41-3857-4c02-9069-9893ddac041d" />

Also added Readme file, and the startWBS.sh script.

# Update:
Combined the observed-maser sensors into one record.
<img width="652" height="617" alt="image" src="https://github.com/user-attachments/assets/251a066a-6818-4cf8-bfeb-972b58e758b5" />

<img width="1515" height="470" alt="image" src="https://github.com/user-attachments/assets/23f5df45-518a-4296-96a3-a6dd641c88a9" />

Added observation details sensor to file.

<img width="3050" height="245" alt="image" src="https://github.com/user-attachments/assets/8fe116fa-bfc7-4227-9b29-b6082e57af62" />

[AT-1349](https://skaafrica.atlassian.net/browse/AT-1349)

[AT-1349]: https://skaafrica.atlassian.net/browse/AT-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ